### PR TITLE
Fix calculation of mean_squared_log_error

### DIFF
--- a/src/CrossValidation/Reports/ResidualAnalysis.php
+++ b/src/CrossValidation/Reports/ResidualAnalysis.php
@@ -49,7 +49,7 @@ class ResidualAnalysis implements Report
 
         $muHat = Stats::mean($labels);
 
-        $errors = $l1 = $l2 = [];
+        $errors = $l1 = $l2 = $log = [];
 
         $sse = $sst = 0.;
 
@@ -60,6 +60,7 @@ class ResidualAnalysis implements Report
 
             $l1[] = abs($error);
             $l2[] = $t = $error ** 2;
+            $log[] = log((1 + $label) / (1 + $prediction)) ** 2;
 
             $sse += $t;
             $sst += ($label - $muHat) ** 2;
@@ -68,6 +69,7 @@ class ResidualAnalysis implements Report
         [$mean, $variance] = Stats::meanVar($errors);
 
         $mse = Stats::mean($l2);
+        $msle = Stats::mean($log);
 
         $r2 = 1. - ($sse / ($sst ?: EPSILON));
 
@@ -76,7 +78,7 @@ class ResidualAnalysis implements Report
             'median_absolute_error' => Stats::median($l1),
             'mean_squared_error' => $mse,
             'rms_error' => sqrt($mse),
-            'mean_squared_log_error' => log($mse),
+            'mean_squared_log_error' => $msle,
             'r_squared' => $r2,
             'error_mean' => $mean,
             'error_variance' => $variance,

--- a/tests/CrossValidation/Reports/ResidualAnalysisTest.php
+++ b/tests/CrossValidation/Reports/ResidualAnalysisTest.php
@@ -31,7 +31,7 @@ class ResidualAnalysisTest extends TestCase
             'mean_absolute_error' => 0.8,
             'median_absolute_error' => 1.,
             'mean_squared_error' => 1,
-            'mean_squared_log_error' => 0.,
+            'mean_squared_log_error' => 0.019107097505647368,
             'rms_error' => 1.,
             'error_mean' => -0.2,
             'error_variance' => 0.9599999999999997,


### PR DESCRIPTION
Instead of focusing on who copies the code from whom and how well the license is understood (https://github.com/php-ai/php-ml/issues/379), let's focus on providing the correct value.

Here is an example from sklearn package:
![Screenshot from 2019-05-14 08-14-24](https://user-images.githubusercontent.com/8239917/57674739-5777a280-7620-11e9-91a8-c7f129d12a3a.png)
