### PR TITLE
Fix `$estimate->proba` not preprocessing dataset in pipeline

### DIFF
--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -272,6 +272,8 @@ class Pipeline implements Online, Wrapper, Probabilistic, Ranking, Persistable, 
             throw new RuntimeException('Base Estimator must'
                 . ' implement the Probabilistic interface.');
         }
+        
+        $this->preprocess($dataset);
 
         return $this->estimator->proba($dataset);
     }


### PR DESCRIPTION
When calling the `proba` method on the Pipeline estimator, the passed dataset is not preprocessed (transformed).

This PR fixes this by adding the preprocess call, as in the `predict` method.