### PR TITLE
Handle multibyte string in text normalizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ $ composer require rubix/ml
 - [GD extension](https://php.net/manual/en/book.image.php) for image manipulation
 - [Redis extension](https://github.com/phpredis/phpredis) for persisting to a Redis DB
 - [Igbinary extension](https://github.com/igbinary/igbinary) for binary serialization of persistables
+- [Multibyte string extension](https://www.php.net/manual/en/book.mbstring.php) for multibyte text transformation
 
 ## Documentation
 Read the latest docs [here](https://docs.rubixml.com).

--- a/benchmarks/Transformers/MultibyteTextNormalizerBench.php
+++ b/benchmarks/Transformers/MultibyteTextNormalizerBench.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Rubix\ML\Benchmarks\Transformers;
+
+use Rubix\ML\Datasets\Unlabeled;
+use Rubix\ML\Transformers\MultibyteTextNormalizer;
+
+/**
+ * @Groups({"Transformers"})
+ * @BeforeMethods({"setUp"})
+ */
+class MultibyteTextNormalizerBench
+{
+    protected const DATASET_SIZE = 100000;
+
+    /**
+     * @var \Rubix\ML\Datasets\Unlabeled
+     */
+    public $dataset;
+
+    /**
+     * @var \Rubix\ML\Transformers\TextNormalizer
+     */
+    protected $transformer;
+
+    public function setUp() : void
+    {
+        $text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at nisl posuere, luctus sapien vel, maximus ex. Curabitur tincidunt, libero at commodo tempor, magna neque malesuada diam, vel blandit metus velit quis magna. Vestibulum auctor libero quam, eu ullamcorper nulla dapibus a. Mauris id ultricies sapien. Integer consequat mi eget vehicula vulputate. Mauris cursus nisi non semper dictum. Quisque luctus ex in tortor laoreet tincidunt. Vestibulum imperdiet purus sit amet sapien dignissim elementum. Mauris tincidunt eget ex eu laoreet. Etiam efficitur quam at purus sagittis hendrerit. Mauris tempus, sem in pulvinar imperdiet, lectus ipsum molestie ante, id semper nunc est sit amet sem. Nulla at justo eleifend, gravida neque eu, consequat arcu. Vivamus bibendum eleifend metus, id elementum orci aliquet ac. Praesent pellentesque nisi vitae tincidunt eleifend. Pellentesque quis ex et lorem laoreet hendrerit ut ac lorem. Aliquam non sagittis est.';
+        $words = array_merge(['    ', '  ', '      '], explode(' ', $text));
+        $samples = [];
+
+        for ($i = 0; $i < self::DATASET_SIZE; $i++) {
+            shuffle($words);
+            $samples[] = [implode(' ', $words)];
+        }
+
+        $this->dataset = new Unlabeled($samples);
+
+        $this->transformer = new MultibyteTextNormalizer();
+    }
+
+    /**
+     * @Subject
+     * @Iterations(3)
+     * @OutputTimeUnit("seconds", precision=3)
+     */
+    public function apply() : void
+    {
+        $this->dataset->apply($this->transformer);
+    }
+}

--- a/benchmarks/Transformers/MultibyteTextNormalizerBench.php
+++ b/benchmarks/Transformers/MultibyteTextNormalizerBench.php
@@ -19,7 +19,7 @@ class MultibyteTextNormalizerBench
     public $dataset;
 
     /**
-     * @var \Rubix\ML\Transformers\TextNormalizer
+     * @var \Rubix\ML\Transformers\MultibyteTextNormalizer
      */
     protected $transformer;
 

--- a/benchmarks/Transformers/TextNormalizerBench.php
+++ b/benchmarks/Transformers/TextNormalizerBench.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Rubix\ML\Benchmarks\Transformers;
+
+use Rubix\ML\Datasets\Unlabeled;
+use Rubix\ML\Transformers\TextNormalizer;
+
+/**
+ * @Groups({"Transformers"})
+ * @BeforeMethods({"setUp"})
+ */
+class TextNormalizerBench
+{
+    protected const DATASET_SIZE = 100000;
+
+    /**
+     * @var \Rubix\ML\Datasets\Unlabeled
+     */
+    public $dataset;
+
+    /**
+     * @var \Rubix\ML\Transformers\TextNormalizer
+     */
+    protected $transformer;
+
+    public function setUp() : void
+    {
+        $text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at nisl posuere, luctus sapien vel, maximus ex. Curabitur tincidunt, libero at commodo tempor, magna neque malesuada diam, vel blandit metus velit quis magna. Vestibulum auctor libero quam, eu ullamcorper nulla dapibus a. Mauris id ultricies sapien. Integer consequat mi eget vehicula vulputate. Mauris cursus nisi non semper dictum. Quisque luctus ex in tortor laoreet tincidunt. Vestibulum imperdiet purus sit amet sapien dignissim elementum. Mauris tincidunt eget ex eu laoreet. Etiam efficitur quam at purus sagittis hendrerit. Mauris tempus, sem in pulvinar imperdiet, lectus ipsum molestie ante, id semper nunc est sit amet sem. Nulla at justo eleifend, gravida neque eu, consequat arcu. Vivamus bibendum eleifend metus, id elementum orci aliquet ac. Praesent pellentesque nisi vitae tincidunt eleifend. Pellentesque quis ex et lorem laoreet hendrerit ut ac lorem. Aliquam non sagittis est.';
+        $words = array_merge(['    ', '  ', '      '], explode(' ', $text));
+        $samples = [];
+
+        for ($i = 0; $i < self::DATASET_SIZE; $i++) {
+            shuffle($words);
+            $samples[] = [implode(' ', $words)];
+        }
+
+        $this->dataset = new Unlabeled($samples);
+
+        $this->transformer = new TextNormalizer();
+    }
+
+    /**
+     * @Subject
+     * @Iterations(3)
+     * @OutputTimeUnit("seconds", precision=3)
+     */
+    public function apply() : void
+    {
+        $this->dataset->apply($this->transformer);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpunit/phpunit": "8.5.*"
     },
     "suggest": {
-        "ext-mbstring": "For MultibyteTextNormalizer",
+        "ext-mbstring": "For fast multibyte string manipulation.",
         "ext-tensor": "For fast Matrix/Vector computing",
         "ext-svm": "For Support Vector Machine engine (libsvm)",
         "ext-gd": "For image vectorization",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "php": ">=7.2",
         "amphp/parallel": "^1.3",
         "psr/log": "^1.1",
-        "rubix/tensor": "^2.0"
+        "rubix/tensor": "^2.0",
+        "symfony/polyfill-mbstring": "~1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.16.*",
@@ -41,6 +42,7 @@
         "phpunit/phpunit": "8.5.*"
     },
     "suggest": {
+        "ext-mbstring": "For MultibyteTextNormalizer",
         "ext-tensor": "For fast Matrix/Vector computing",
         "ext-svm": "For Support Vector Machine engine (libsvm)",
         "ext-gd": "For image vectorization",

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ $ composer require rubix/ml
 - [GD extension](https://php.net/manual/en/book.image.php) for image manipulation
 - [Redis extension](https://github.com/phpredis/phpredis) for persisting to a Redis DB
 - [Igbinary extension](https://github.com/igbinary/igbinary) for binary serialization of persistables
+- [Multibyte string extension](https://www.php.net/manual/en/book.mbstring.php) for multibyte text transformation
 
 ## What is Rubix ML?
 Rubix ML is a free open-source library for the PHP language that allows you to build programs that learn from your data. We provide tools for the entire machine learning life cycle from ETL to training, validation, and production with over 40 supervised and unsupervised learning algorithms.

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -121,6 +121,7 @@ For natural language processing (NLP) tasks, cleaning the text will help elimina
 - [HTML Stripper](transformers/html-stripper.md)
 - [Regex Filter](transformers/regex-filter.md)
 - [Text Normalizer](transformers/text-normalizer.md)
+- [Multibyte Text Normalizer](transformers/multibyte-text-normalizer.md)
 - [Stop Word Filter](transformers/stop-word-filter.md)
 
 ## Image Processing

--- a/docs/transformers/multibyte-text-normalizer.md
+++ b/docs/transformers/multibyte-text-normalizer.md
@@ -1,0 +1,25 @@
+<span style="float:right;"><a href="https://github.com/RubixML/RubixML/blob/master/src/Transformers/MultibyteTextNormalizer.php">[source]</a></span>
+
+# Multibyte Text Normalizer
+This transformer converts all [multibyte text](https://www.php.net/manual/en/intro.mbstring.php) to lowercase and removes extra whitespace.
+
+Multibyte string contains multibyte characters sush as accented characters (é, è, à, ...), emojis (😀, 😉, ...) or characters of non roman alphabets (Chinese, Cyrillic, ...). 
+
+**Interfaces:** [Transformer](api.md#transformer)
+
+**Data Type Compatibility:** Categorical
+
+> **Note:** ⚠️ We recommend you install the [Multibyte string extension](https://www.php.net/manual/en/book.mbstring.php) for best performance.
+
+## Parameters
+This transformer does not have any parameters.
+
+## Additional Methods
+This transformer does not have any additional methods.
+
+## Example
+```php
+use Rubix\ML\Transformers\MultibyteTextNormalizer;
+
+$transformer = new MultibyteTextNormalizer();
+```

--- a/docs/transformers/text-normalizer.md
+++ b/docs/transformers/text-normalizer.md
@@ -7,6 +7,8 @@ This transformer converts all text to lowercase and removes extra whitespace.
 
 **Data Type Compatibility:** Categorical
 
+> **Note:** ⚠️ This transformer can't handle multibyte text properly. For multibyte text, use [MultibyteTextNormalizer](multibyte-text-normalizer.md).
+
 ## Parameters
 This transformer does not have any parameters.
 
@@ -17,5 +19,5 @@ This transformer does not have any additional methods.
 ```php
 use Rubix\ML\Transformers\TextNormalizer;
 
-$transformer = new TextNormalizer(true);
+$transformer = new TextNormalizer();
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
     - HTML Stripper: transformers/html-stripper.md
     - Regex Filter: transformers/regex-filter.md
     - Text Normalizer: transformers/text-normalizer.md
+    - Multibyte Text Normalizer: transformers/multibyte-text-normalizer.md
     - Stop Word Filter: transformers/stop-word-filter.md
 - Neural Network:
   - Activation Functions:

--- a/src/Transformers/MultibyteTextNormalizer.php
+++ b/src/Transformers/MultibyteTextNormalizer.php
@@ -11,7 +11,7 @@ use Rubix\ML\DataType;
  *
  * @category    Machine Learning
  * @package     Rubix/ML
- * @author      Andrew DalPino
+ * @author      Maxime Colin
  */
 class MultibyteTextNormalizer implements Transformer
 {

--- a/src/Transformers/MultibyteTextNormalizer.php
+++ b/src/Transformers/MultibyteTextNormalizer.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Rubix\ML\Transformers;
+
+use Rubix\ML\DataType;
+
+/**
+ * Multibyte Text Normalizer
+ *
+ * This transformer converts all multibyte text to lowercase and removes extra whitespace.
+ *
+ * @category    Machine Learning
+ * @package     Rubix/ML
+ * @author      Andrew DalPino
+ */
+class MultibyteTextNormalizer implements Transformer
+{
+    /**
+     * A pattern to match whitespace.
+     *
+     * @var string
+     */
+    protected const SPACES_REGEX = '/\s+/';
+
+    /**
+     * A whitespace character.
+     *
+     * @var string
+     */
+    protected const SPACE = ' ';
+
+    /**
+     * Return the data types that this transformer is compatible with.
+     *
+     * @return \Rubix\ML\DataType[]
+     */
+    public function compatibility() : array
+    {
+        return DataType::all();
+    }
+
+    /**
+     * Transform the dataset in place.
+     *
+     * @param array[] $samples
+     */
+    public function transform(array &$samples) : void
+    {
+        foreach ($samples as &$sample) {
+            foreach ($sample as &$value) {
+                if (is_string($value)) {
+                    $value = mb_strtolower(preg_replace(self::SPACES_REGEX, self::SPACE, trim($value)) ?: '');
+                }
+            }
+        }
+    }
+}

--- a/tests/Transformers/MultibyteTextNormalizerTest.php
+++ b/tests/Transformers/MultibyteTextNormalizerTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @group Transformers
- * @covers \Rubix\ML\Transformers\TextNormalizer
+ * @covers \Rubix\ML\Transformers\MultibyteTextNormalizer
  */
 class MultibyteTextNormalizerTest extends TestCase
 {
@@ -19,7 +19,7 @@ class MultibyteTextNormalizerTest extends TestCase
     protected $dataset;
 
     /**
-     * @var \Rubix\ML\Transformers\TextNormalizer
+     * @var \Rubix\ML\Transformers\MultibyteTextNormalizer
      */
     protected $transformer;
 

--- a/tests/Transformers/MultibyteTextNormalizerTest.php
+++ b/tests/Transformers/MultibyteTextNormalizerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Rubix\ML\Tests\Transformers;
+
+use Rubix\ML\Datasets\Unlabeled;
+use Rubix\ML\Transformers\MultibyteTextNormalizer;
+use Rubix\ML\Transformers\Transformer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group Transformers
+ * @covers \Rubix\ML\Transformers\TextNormalizer
+ */
+class MultibyteTextNormalizerTest extends TestCase
+{
+    /**
+     * @var \Rubix\ML\Datasets\Unlabeled
+     */
+    protected $dataset;
+
+    /**
+     * @var \Rubix\ML\Transformers\TextNormalizer
+     */
+    protected $transformer;
+
+    /**
+     * @before
+     */
+    protected function setUp() : void
+    {
+        $this->dataset = Unlabeled::quick([
+            ['The quick brown fox jumped over the lazy man sitting at a bus'
+                . ' stop drinking a can of Coke'],
+            ['with a Dandy   umbrella '],
+            ['Depuis qu’il   avait emménagé à côté de chez elle, il y a de ça cinq ans. '],
+            ['   Working   with emoji 🤓 '],
+        ]);
+
+        $this->transformer = new MultibyteTextNormalizer();
+    }
+    
+    /**
+     * @test
+     */
+    public function build() : void
+    {
+        $this->assertInstanceOf(MultibyteTextNormalizer::class, $this->transformer);
+        $this->assertInstanceOf(Transformer::class, $this->transformer);
+    }
+    
+    /**
+     * @test
+     */
+    public function transform() : void
+    {
+        $this->dataset->apply($this->transformer);
+    
+        $outcome = [
+            ['the quick brown fox jumped over the lazy man sitting at a bus'
+                . ' stop drinking a can of coke'],
+            ['with a dandy umbrella'],
+            ['depuis qu’il avait emménagé à côté de chez elle, il y a de ça cinq ans.'],
+            ['working with emoji 🤓'],
+        ];
+    
+        $this->assertEquals($outcome, $this->dataset->samples());
+    }
+}


### PR DESCRIPTION
## Problem

`TextNormalizer` is unable to deal with string containing accents, chars like "é" or "è" are replaced by `?`.

Input: "Depuis qu’il avait emménagé à côté de chez elle, il y a de ça cinq ans."
Output: "depuis qu’il avait emm?nag? ? c?t? de chez elle, il y a de ?a cinq ans."

## Fix

Use `mb_strtolower` instead of `strtolower`.
