### PR TITLE
Enable unicode flag on stopword regex

### DIFF
--- a/src/Transformers/StopWordFilter.php
+++ b/src/Transformers/StopWordFilter.php
@@ -32,7 +32,7 @@ class StopWordFilter extends RegexFilter
                     . ' string, ' . gettype($word) . ' found.');
             }
 
-            $patterns[] = '/\b' . preg_quote($word, '/') . '\b/';
+            $patterns[] = '/\b' . preg_quote($word, '/') . '\b/u';
         }
 
         parent::__construct($patterns);

--- a/tests/Transformers/StopWordFilterTest.php
+++ b/tests/Transformers/StopWordFilterTest.php
@@ -32,9 +32,10 @@ class StopWordFilterTest extends TestCase
             ['the quick brown fox jumped over the lazy man sitting at a bus'
                 . ' stop drinking a can of coke'],
             ['with a dandy umbrella'],
+            ['salle à manger'],
         ]);
 
-        $this->transformer = new StopWordFilter(['a', 'quick', 'pig']);
+        $this->transformer = new StopWordFilter(['a', 'quick', 'pig', 'à']);
     }
     
     /**
@@ -56,6 +57,7 @@ class StopWordFilterTest extends TestCase
         $expected = [
             ['the  brown fox jumped over the lazy man sitting at  bus stop drinking  can of coke'],
             ['with  dandy umbrella'],
+            ['salle  manger'],
         ];
     
         $this->assertEquals($expected, $this->dataset->samples());


### PR DESCRIPTION
Allow `StopWordFilter` to handle stop words with accents by enabling the unicode (`u`) flag on the regex.