### PR TITLE
Better keywords for findability on Packagist.org

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,11 @@
     "license": "MIT",
     "readme": "README.md",
     "keywords": [
-        "php", "machine-learning", "data-science", "data-mining", "predictive-modeling", "prediction", "classification",
-        "regression", "clustering", "anomaly-detection", "neural-network", "manifold-learning",
-        "dimensionality-reduction", "artificial-intelligence", "ai", "cross-validation", "feature-extraction",
-        "deep-learning", "rubix", "ml", "analytics", "naive-bayes", "k-means", "k-nearest-neighbors", "recommendation" 
+        "php", "machine learning", "data science", "data mining", "predictive modeling", "prediction", "classification",
+        "classifier", "regression", "clustering", "anomaly detection", "neural network", "manifold learning",
+        "dimensionality reduction", "artificial intelligence", "ai", "cross validation", "feature extraction",
+        "deep learning", "rubix", "ml", "analytics", "naive bayes", "naive", "bayes", "k-means", "kmeans", 
+        "k-nearest neighbors", "knn", "recommendation" 
     ],
     "authors": [
         {


### PR DESCRIPTION
1- Because of https://github.com/composer/packagist/issues/1091 we are better off to use spaces than hyphens. I left k-means and k-nearest because that is the proper spelling.
2- I added a few more relevant keyworks which are used on Packagist.org