### PR TITLE
Optimize Cosine distance kernel - skip normalizing vectors if product is zero

### DIFF
--- a/src/Kernels/Distance/Cosine.php
+++ b/src/Kernels/Distance/Cosine.php
@@ -52,9 +52,15 @@ class Cosine implements Distance, Stringable
             $valueB = $b[$i];
 
             $sigma += $valueA * $valueB;
+        }
 
-            $ssA += $valueA ** 2;
-            $ssB += $valueB ** 2;
+        if (abs($sigma) > EPSILON) {
+            foreach ($a as $i => $valueA) {
+                $valueB = $b[$i];
+
+                $ssA += $valueA ** 2;
+                $ssB += $valueB ** 2;
+            }
         }
 
         return 1.0 - ($sigma / (sqrt($ssA * $ssB) ?: EPSILON));


### PR DESCRIPTION
A simple optimization for sparse vectors - we don't need to calculate the normalized vector forms if vector product is zero. Let me know if the zero comparison is OK, not sure I found how you do it in other places...