### PR TITLE
Remote filesystems

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,8 @@
     "require": {
         "php": ">=7.2",
         "amphp/parallel": "^1.3",
+        "league/flysystem": "^1.1",
+        "league/flysystem-memory": "^1.0",
         "psr/log": "^1.1",
         "rubix/tensor": "^2.0",
         "symfony/polyfill-mbstring": "^1.0",

--- a/docs/extractors/csv.md
+++ b/docs/extractors/csv.md
@@ -8,10 +8,11 @@ A plain-text format that use newlines to delineate rows and a user-specified del
 ## Parameters
 | # | Param | Default | Type | Description |
 |---|---|---|---|---|
-| 1 | path |  | string | The path to the CSV file. |
-| 2 | header | false | bool | Does the CSV document have a header as the first row? |
-| 3 | delimiter | ',' | string | The character that delineates the values of the columns of the data table. |
-| 4 | enclosure | '"' | string | The character used to enclose a cell that contains a delimiter in the body. |
+| 1 | path |  | `string` | The path to the CSV file. |
+| 2 | header | `false` | `bool` | Does the CSV document have a header as the first row? |
+| 3 | delimiter | '`,`' | `string` | The character that delineates the values of the columns of the data table. |
+| 4 | enclosure | '`"`' | `string` | The character used to enclose a cell that contains a delimiter in the body. |
+| 5 | filesystem | `Storage::local()`  | `Filesystem` | The filesystem to read from. The default behaviour is to target the local filesystem.  |
 
 ## Example
 ```php

--- a/docs/extractors/json.md
+++ b/docs/extractors/json.md
@@ -3,10 +3,12 @@
 # JSON
 Javascript Object Notation is a standardized lightweight plain-text representation that is widely used. JSON has the advantage of retaining type information, however since the entire JSON blob is read on load, it is not cursorable like CSV or NDJSON.
 
+
 ## Parameters
 | # | Param | Default | Type | Description |
 |---|---|---|---|---|
-| 1 | path |  | string | The path to the JSON file. |
+| 1 | path |  | `string` | The path to the JSON file. |
+| 2 | filesystem | `Storage::local()`  | `Filesystem` | The filesystem to read from. The default behaviour is to target the local filesystem.  |
 
 ## Example
 ```php

--- a/docs/extractors/ndjson.md
+++ b/docs/extractors/ndjson.md
@@ -9,6 +9,7 @@
 | # | Param | Default | Type | Description |
 |---|---|---|---|---|
 | 1 | path |  | string | The path to the NDJSON file. |
+| 2 | filesystem | `Storage::local()`  | `Filesystem` | The filesystem to read from. The default behaviour is to target the local filesystem.  |
 
 ## Example
 ```php

--- a/docs/persisters/filesystem.md
+++ b/docs/persisters/filesystem.md
@@ -3,19 +3,25 @@
 # Filesystem
 Filesystems are local or remote storage drives that are organized by files and folders. The Filesystem persister saves models to a file at a given path and can automatically keep a history of past saved models.
 
+This class uses the local filesystem by default, but remote filesystems (such as Amazon S3, Azure Blob Storage, Dropbox, PDO Database etc...) are also supported by configuring the `Filesystem` object and passing it to the constructor of this class. 
+
+See: [Filesystem Adapters](https://github.com/thephpleague/flysystem#adapters).
+
 ## Parameters
 | # | Param | Default | Type | Description |
 |---|---|---|---|---|
-| 1 | path | | string | The path to the model file on the filesystem. |
-| 2 | history | false | bool | Should we keep a history of past saves? |
-| 3 | serializer | Native | Serializer | The serializer used to convert to and from storage format. |
+| 1 | path | | `string` | The path to the model file on the filesystem. |
+| 2 | history | `false` | `bool` | Should we keep a history of past saves? |
+| 3 | serializer | `Native` | `Serializer` | The serializer used to convert to and from storage format. |
+| 4 | filesystem | `Storage::local()` | `Filesystem` | The filesystem to use as a storage backend. By default the local filesystem is used |
 
 ## Example
 ```php
+use Rubix\ML\Other\Helpers\Storage;
 use Rubix\ML\Persisters\Filesystem;
 use Rubix\ML\Persisters\Serializers\Igbinary;
 
-$persister = new Filesystem('/path/to/example.model', true, new Iginary());
+$persister = new Filesystem('/path/to/example.model', true, new Iginary(), Storage::local());
 ```
 
 ## Additional Methods

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,8 @@ includes:
 
 parameters:
     level: 8
+    bootstrapFiles:
+        - src/constants.php
     paths:
         - 'src'
         - 'tests'

--- a/src/Encoding.php
+++ b/src/Encoding.php
@@ -2,6 +2,8 @@
 
 namespace Rubix\ML;
 
+use League\Flysystem\FilesystemInterface;
+use Rubix\ML\Other\Helpers\Storage;
 use RuntimeException;
 use Stringable;
 
@@ -46,19 +48,16 @@ class Encoding implements Stringable
      * Write the encoding to a file at the path specified.
      *
      * @param string $path
-     * @throws \RuntimeException
+     * @param FilesystemInterface|null $filesystem The filesystem to use. If null this method uses the local filesystem
+     * @throws \Exception If the file cannot be successfully written to the filesystem
      */
-    public function write(string $path) : void
+    public function write(string $path, ?FilesystemInterface $filesystem = null) : void
     {
-        if (!is_file($path) and !is_writable(dirname($path))) {
-            throw new RuntimeException('Folder does not exist or is not writable');
+        if (!$filesystem) {
+            $filesystem = Storage::local();
         }
 
-        if (is_file($path) and !is_writable($path)) {
-            throw new RuntimeException("File $path is not writable.");
-        }
-
-        $success = file_put_contents($path, $this->data, LOCK_EX);
+        $success = $filesystem->write($path, $this->data());
 
         if (!$success) {
             throw new RuntimeException('Failed to write to the filesystem.');

--- a/src/FilesystemAware.php
+++ b/src/FilesystemAware.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rubix\ML;
+
+use League\Flysystem\FilesystemInterface;
+
+interface FilesystemAware
+{
+    /**
+     * Return a Filesystem instance.
+     *
+     * @return FilesystemInterface
+     */
+    public function filesystem() : FilesystemInterface;
+}

--- a/src/Other/Helpers/Storage.php
+++ b/src/Other/Helpers/Storage.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Rubix\ML\Other\Helpers;
+
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\AdapterInterface;
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemInterface;
+use League\Flysystem\Memory\MemoryAdapter;
+use League\Flysystem\Adapter\Ftp;
+
+/**
+ * Storage
+ *
+ * A helper class providing functions relating to storage/persistence.
+ *
+ * @category    Machine Learning
+ * @package     Rubix/ML
+ * @author      Andrew DalPino
+ */
+class Storage
+{
+    /**
+     * Returns a Filesystem instance backed by the provided filesystem.
+     *
+     *
+     * @param AdapterInterface $adapter
+     * @param array<mixed> $config
+     *
+     * @return FilesystemInterface
+     */
+    public static function filesystem(AdapterInterface $adapter, array $config = []) : FilesystemInterface
+    {
+        return new Filesystem($adapter, $config);
+    }
+
+    /**
+     * Returns a Filesystem instance backed by the local filesystem.
+     *
+     * @param string $root
+     * @param array<mixed> $config
+     *
+     * @return FilesystemInterface
+     */
+    public static function local(string $root = '/', array $config = []) : FilesystemInterface
+    {
+        return self::filesystem(new Local($root), $config);
+    }
+
+    /**
+     * Returns a Filesystem instance backed by a remote FTP server.
+     *
+     * @param array<mixed> $ftpConfig
+     * @param array<mixed> $config
+     *
+     * @return FilesystemInterface
+     */
+    public static function ftp(array $ftpConfig, array $config = []) : FilesystemInterface
+    {
+        return self::filesystem(new Ftp($ftpConfig), $config);
+    }
+
+    /**
+     * Returns a Filesystem instance backed by an in-memory mock filesystem.
+     * Suitable for use in tests or when long-term persistence isn't required.
+     *
+     * @param array<mixed> $config
+     * @return FilesystemInterface
+     */
+    public static function memory(array $config = []) : FilesystemInterface
+    {
+        return self::filesystem(new MemoryAdapter(), $config);
+    }
+}

--- a/src/Other/Traits/FilesystemTrait.php
+++ b/src/Other/Traits/FilesystemTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Rubix\ML\Other\Traits;
+
+use League\Flysystem\FilesystemInterface;
+use Rubix\ML\Other\Helpers\Storage;
+
+/**
+ * Filesystem Aware
+ *
+ * This trait can be used in classes that internally read or write to a filesystem. It provides a default implementation
+ * of \Rubix\ML\FilesystemAware interface
+ *
+ *
+ * @category    Machine Learning
+ * @package     Rubix/ML
+ * @author      Andrew DalPino
+ */
+trait FilesystemTrait
+{
+    /**
+     * The Filesystem instance to perform filesystem operations using
+     *
+     * @var ?FilesystemInterface
+     */
+    protected $filesystem;
+
+    public function setFilesystem(FilesystemInterface $filesystem) : void
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * Return the target filesystem instance.
+     * If the user has not provided one when instantiating, or not invoked setFilesystem()  then this method
+     * returns a reference to to local filesystem.
+     *
+     * @return FilesystemInterface
+     */
+    public function filesystem() : FilesystemInterface
+    {
+        if (!$this->filesystem) {
+            $this->filesystem = Storage::local();
+        }
+
+        return $this->filesystem;
+    }
+}

--- a/src/constants.php
+++ b/src/constants.php
@@ -1,7 +1,25 @@
 <?php
 
-namespace Rubix\ML
-{
+namespace {
+
+    /**
+     * PROJECT_DIR defines the directory path to the root of this project.
+     *
+     * ~@var string
+     */
+    define('PROJECT_DIR', dirname(__DIR__));
+
+    /**
+     * TMP_DIR defines the directory path used for temporary files.
+     *
+     * ~@var string
+     */
+    define('TMP_DIR', sys_get_temp_dir());
+
+}
+
+namespace Rubix\ML {
+
     /**
      * A small number used in substitution of 0.
      *

--- a/tests/Datasets/LabeledTest.php
+++ b/tests/Datasets/LabeledTest.php
@@ -83,7 +83,7 @@ class LabeledTest extends TestCase
      */
     public function fromIterator() : void
     {
-        $dataset = Labeled::fromIterator(new NDJSON('tests/test.ndjson'));
+        $dataset = Labeled::fromIterator(new NDJSON(PROJECT_DIR . '/tests/test.ndjson'));
 
         $this->assertInstanceOf(Labeled::class, $dataset);
         $this->assertEquals(self::SAMPLES, $dataset->samples());

--- a/tests/Datasets/UnlabeledTest.php
+++ b/tests/Datasets/UnlabeledTest.php
@@ -75,7 +75,7 @@ class UnlabeledTest extends TestCase
      */
     public function fromIterator() : void
     {
-        $dataset = Unlabeled::fromIterator(new NDJSON('tests/test.ndjson'));
+        $dataset = Unlabeled::fromIterator(new NDJSON(PROJECT_DIR . '/tests/test.ndjson'));
 
         $this->assertInstanceOf(Unlabeled::class, $dataset);
     }

--- a/tests/Extractors/CSVTest.php
+++ b/tests/Extractors/CSVTest.php
@@ -24,7 +24,7 @@ class CSVTest extends TestCase
      */
     protected function setUp() : void
     {
-        $this->extractor = new CSV('tests/test.csv', true, ',', '"');
+        $this->extractor = new CSV(PROJECT_DIR . '/tests/test.csv', true, ',', '"');
     }
 
     /**

--- a/tests/Extractors/ColumnPickerTest.php
+++ b/tests/Extractors/ColumnPickerTest.php
@@ -25,7 +25,7 @@ class ColumnPickerTest extends TestCase
      */
     protected function setUp() : void
     {
-        $this->extractor = new ColumnPicker(new CSV('tests/test.csv', true), [
+        $this->extractor = new ColumnPicker(new CSV(PROJECT_DIR . '/tests/test.csv', true), [
             'attitude', 'texture', 'class', 'rating',
         ]);
     }

--- a/tests/Extractors/JSONTest.php
+++ b/tests/Extractors/JSONTest.php
@@ -24,7 +24,7 @@ class JSONTest extends TestCase
      */
     protected function setUp() : void
     {
-        $this->extractor = new JSON('tests/test.json');
+        $this->extractor = new JSON(PROJECT_DIR . '/tests/test.json');
     }
 
     /**

--- a/tests/Extractors/NDJSONTest.php
+++ b/tests/Extractors/NDJSONTest.php
@@ -24,7 +24,7 @@ class NDJSONTest extends TestCase
      */
     protected function setUp() : void
     {
-        $this->extractor = new NDJSON('tests/test.ndjson');
+        $this->extractor = new NDJSON(PROJECT_DIR . '/tests/test.ndjson');
     }
 
     /**

--- a/tests/Other/Helpers/StorageTest.php
+++ b/tests/Other/Helpers/StorageTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rubix\ML\Tests\Other\Helpers;
+
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemInterface;
+use League\Flysystem\Memory\MemoryAdapter;
+use PHPUnit\Framework\TestCase;
+use Rubix\ML\Other\Helpers\Storage;
+
+/**
+ * @group Helpers
+ * @covers \Rubix\ML\Other\Helpers\Storage
+ */
+class StorageTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function local() : void
+    {
+        /** @var Filesystem */
+        $filesystem = Storage::local();
+
+        $this->assertInstanceOf(FilesystemInterface::class, $filesystem);
+        $this->assertInstanceOf(Filesystem::class, $filesystem);
+        $this->assertInstanceOf(Local::class, $filesystem->getAdapter());
+    }
+
+    /**
+     * @test
+     */
+    public function memory() : void
+    {
+        /** @var Filesystem */
+        $filesystem = Storage::memory();
+
+        $this->assertInstanceOf(FilesystemInterface::class, $filesystem);
+        $this->assertInstanceOf(Filesystem::class, $filesystem);
+        $this->assertInstanceOf(MemoryAdapter::class, $filesystem->getAdapter());
+    }
+}


### PR DESCRIPTION
###### SUMMARY:

This PR introduces a pluggable filesystem into RubixML. Classes that currently interact with the local filesystem have been updated to be a `FilesystemAware`. Backwards-compatibility is maintained by defaulting to the local filesystem, but this change allows users increased flexibility and the choice to connect to remote filesystems/storage backends (Amazon S3, Azure Storage, Google Cloud Storage, Dropbox, FTP Server [etc...](https://github.com/thephpleague/flysystem#adapters)) just as easily. This work came as a result of some discussion in #104.

###### NOTES:

- The filesystem abstraction is provided by [`league/flysystem`](https://packagist.org/packages/league/flysystem).
- The `CSV`, `JSON`, `NDJSON` [Extractors](https://docs.rubixml.com/en/latest/extractors/api.html) have all been made `FilesystemAware`.  By default they continue to read from the local filesystem, but can now easily be configured to connect to a remote filesystem.
- The [`Filesystem`](https://docs.rubixml.com/en/latest/persisters/filesystem.html#filesystem) Persister also now implements `FilesystemAware`. It optionally accepts a different filesystem as a constructor argument.


###### EXAMPLE:

To read my json from an remote FTP server instead of the local filesystem, I could configure my code like this:
```php
<?php

use Rubix\ML\Datasets\Labeled;
use Rubix\ML\Extractors\JSON;
use Rubix\ML\Other\Helpers\Storage;


$config = [
    'host' => 'ftp.example.com',
    'username' => 'username',
    'password' => 'password',
];

$filesystem = Storage::ftp($config);

$dataset = Labeled::fromIterator(new JSON('example.json', $filesystem));

```