### PR TITLE
Exceptions

### DIFF
--- a/src/AnomalyDetectors/GaussianMLE.php
+++ b/src/AnomalyDetectors/GaussianMLE.php
@@ -19,8 +19,8 @@ use Rubix\ML\Other\Traits\PredictsSingle;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function Rubix\ML\warn_deprecated;
@@ -90,7 +90,7 @@ class GaussianMLE implements Estimator, Learner, Online, Scoring, Ranking, Persi
 
     /**
      * @param float $contamination
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $contamination = 0.1)
     {
@@ -259,7 +259,7 @@ class GaussianMLE implements Estimator, Learner, Online, Scoring, Ranking, Persi
      * Return the anomaly scores assigned to the samples in a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float>
      */
     public function score(Dataset $dataset) : array

--- a/src/AnomalyDetectors/IsolationForest.php
+++ b/src/AnomalyDetectors/IsolationForest.php
@@ -20,8 +20,8 @@ use Rubix\ML\Other\Traits\PredictsSingle;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function Rubix\ML\warn_deprecated;
@@ -128,7 +128,7 @@ class IsolationForest implements Estimator, Learner, Scoring, Ranking, Persistab
      * @param int $estimators
      * @param float|null $ratio
      * @param float|null $contamination
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $estimators = 100, ?float $ratio = null, ?float $contamination = null)
     {
@@ -259,7 +259,7 @@ class IsolationForest implements Estimator, Learner, Scoring, Ranking, Persistab
      * Return the anomaly scores assigned to the samples in a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float>
      */
     public function score(Dataset $dataset) : array

--- a/src/AnomalyDetectors/LocalOutlierFactor.php
+++ b/src/AnomalyDetectors/LocalOutlierFactor.php
@@ -20,8 +20,8 @@ use Rubix\ML\Other\Traits\PredictsSingle;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function Rubix\ML\warn_deprecated;
@@ -113,7 +113,7 @@ class LocalOutlierFactor implements Estimator, Learner, Scoring, Ranking, Persis
      * @param int $k
      * @param float|null $contamination
      * @param \Rubix\ML\Graph\Trees\Spatial|null $tree
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $k = 20, ?float $contamination = null, ?Spatial $tree = null)
     {
@@ -245,7 +245,7 @@ class LocalOutlierFactor implements Estimator, Learner, Scoring, Ranking, Persis
      * Return the anomaly scores assigned to the samples in a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float>
      */
     public function score(Dataset $dataset) : array

--- a/src/AnomalyDetectors/Loda.php
+++ b/src/AnomalyDetectors/Loda.php
@@ -21,8 +21,8 @@ use Rubix\ML\Other\Traits\PredictsSingle;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function Rubix\ML\warn_deprecated;
@@ -137,7 +137,7 @@ class Loda implements Estimator, Learner, Online, Scoring, Ranking, Persistable,
      * @param int $estimators
      * @param int|null $bins
      * @param float $contamination
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $estimators = 100, ?int $bins = null, float $contamination = 0.1)
     {
@@ -331,7 +331,7 @@ class Loda implements Estimator, Learner, Online, Scoring, Ranking, Persistable,
      * Return the anomaly scores assigned to the samples in a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float>
      */
     public function score(Dataset $dataset) : array

--- a/src/AnomalyDetectors/OneClassSVM.php
+++ b/src/AnomalyDetectors/OneClassSVM.php
@@ -14,8 +14,8 @@ use Rubix\ML\Other\Helpers\Verifier;
 use Rubix\ML\Other\Traits\PredictsSingle;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 use svmmodel;
 use svm;
@@ -68,8 +68,8 @@ class OneClassSVM implements Estimator, Learner, Stringable
      * @param bool $shrinking
      * @param float $tolerance
      * @param float $cacheSize
-     * @throws \RuntimeException
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         float $nu = 0.5,
@@ -171,7 +171,7 @@ class OneClassSVM implements Estimator, Learner, Stringable
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -187,7 +187,7 @@ class OneClassSVM implements Estimator, Learner, Stringable
      * Make predictions from a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<int>
      */
     public function predict(Dataset $dataset) : array
@@ -209,7 +209,7 @@ class OneClassSVM implements Estimator, Learner, Stringable
      * Save the model data to the filesystem.
      *
      * @param string $path
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function save(string $path) : void
     {

--- a/src/AnomalyDetectors/RobustZScore.php
+++ b/src/AnomalyDetectors/RobustZScore.php
@@ -18,8 +18,8 @@ use Rubix\ML\Other\Traits\PredictsSingle;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function Rubix\ML\warn_deprecated;
@@ -91,7 +91,7 @@ class RobustZScore implements Estimator, Learner, Scoring, Ranking, Persistable,
     /**
      * @param float $threshold
      * @param float $alpha
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $threshold = 3.5, float $alpha = 0.5)
     {
@@ -178,7 +178,7 @@ class RobustZScore implements Estimator, Learner, Scoring, Ranking, Persistable,
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -201,8 +201,8 @@ class RobustZScore implements Estimator, Learner, Scoring, Ranking, Persistable,
      * Make predictions from a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<int>
      */
     public function predict(Dataset $dataset) : array
@@ -214,7 +214,7 @@ class RobustZScore implements Estimator, Learner, Scoring, Ranking, Persistable,
      * Return the anomaly scores assigned to the samples in a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float>
      */
     public function score(Dataset $dataset) : array

--- a/src/Backends/Amp.php
+++ b/src/Backends/Amp.php
@@ -8,7 +8,7 @@ use Rubix\ML\Backends\Tasks\Task;
 use Amp\Parallel\Worker\DefaultPool;
 use Amp\Parallel\Worker\CallableTask;
 use Amp\Parallel\Worker\Task as AmpTask;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 use Generator;
 
@@ -55,7 +55,7 @@ class Amp implements Backend, Stringable
 
     /**
      * @param int|null $workers
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(?int $workers = null)
     {

--- a/src/BootstrapAggregator.php
+++ b/src/BootstrapAggregator.php
@@ -14,8 +14,8 @@ use Rubix\ML\Backends\Tasks\TrainLearner;
 use Rubix\ML\Other\Traits\Multiprocessing;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function in_array;
@@ -91,7 +91,7 @@ class BootstrapAggregator implements Estimator, Learner, Parallel, Persistable, 
      * @param \Rubix\ML\Learner $base
      * @param int $estimators
      * @param float $ratio
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(Learner $base, int $estimators = 10, float $ratio = 0.5)
     {
@@ -166,7 +166,7 @@ class BootstrapAggregator implements Estimator, Learner, Parallel, Persistable, 
      * training set.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -201,7 +201,7 @@ class BootstrapAggregator implements Estimator, Learner, Parallel, Persistable, 
      * Make predictions from a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return mixed[]
      */
     public function predict(Dataset $dataset) : array

--- a/src/Classifiers/AdaBoost.php
+++ b/src/Classifiers/AdaBoost.php
@@ -19,8 +19,8 @@ use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function count;
@@ -148,7 +148,7 @@ class AdaBoost implements Estimator, Learner, Probabilistic, Verbose, Persistabl
      * @param int $estimators
      * @param float $minChange
      * @param int $window
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         ?Learner $base = null,
@@ -267,7 +267,7 @@ class AdaBoost implements Estimator, Learner, Probabilistic, Verbose, Persistabl
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -434,7 +434,7 @@ class AdaBoost implements Estimator, Learner, Probabilistic, Verbose, Persistabl
      * Return the influence scores for each sample in the dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float[]>
      */
     protected function score(Dataset $dataset) : array

--- a/src/Classifiers/ClassificationTree.php
+++ b/src/Classifiers/ClassificationTree.php
@@ -22,8 +22,8 @@ use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function Rubix\ML\argmax;
@@ -61,7 +61,7 @@ class ClassificationTree extends CART implements Estimator, Learner, Probabilist
      * @param int $maxLeafSize
      * @param int|null $maxFeatures
      * @param float $minPurityIncrease
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         int $maxHeight = PHP_INT_MAX,
@@ -124,7 +124,7 @@ class ClassificationTree extends CART implements Estimator, Learner, Probabilist
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -148,7 +148,7 @@ class ClassificationTree extends CART implements Estimator, Learner, Probabilist
      * Make predictions from a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<string>
      */
     public function predict(Dataset $dataset) : array
@@ -176,7 +176,7 @@ class ClassificationTree extends CART implements Estimator, Learner, Probabilist
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float[]>
      */
     public function proba(Dataset $dataset) : array

--- a/src/Classifiers/DummyClassifier.php
+++ b/src/Classifiers/DummyClassifier.php
@@ -17,8 +17,8 @@ use Rubix\ML\Other\Strategies\Categorical;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function count;
@@ -106,7 +106,7 @@ class DummyClassifier implements Estimator, Learner, Persistable, Stringable
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -129,7 +129,7 @@ class DummyClassifier implements Estimator, Learner, Persistable, Stringable
      * Make a prediction of a given sample dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<string>
      */
     public function predict(Dataset $dataset) : array

--- a/src/Classifiers/ExtraTreeClassifier.php
+++ b/src/Classifiers/ExtraTreeClassifier.php
@@ -22,8 +22,8 @@ use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function Rubix\ML\argmax;
@@ -61,7 +61,7 @@ class ExtraTreeClassifier extends ExtraTree implements Estimator, Learner, Proba
      * @param int $maxLeafSize
      * @param int|null $maxFeatures
      * @param float $minPurityIncrease
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         int $maxHeight = PHP_INT_MAX,
@@ -124,7 +124,7 @@ class ExtraTreeClassifier extends ExtraTree implements Estimator, Learner, Proba
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -148,7 +148,7 @@ class ExtraTreeClassifier extends ExtraTree implements Estimator, Learner, Proba
      * Make predictions from a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<string>
      */
     public function predict(Dataset $dataset) : array
@@ -176,7 +176,7 @@ class ExtraTreeClassifier extends ExtraTree implements Estimator, Learner, Proba
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float[]>
      */
     public function proba(Dataset $dataset) : array

--- a/src/Classifiers/GaussianNB.php
+++ b/src/Classifiers/GaussianNB.php
@@ -20,8 +20,8 @@ use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function Rubix\ML\logsumexp;
@@ -93,7 +93,7 @@ class GaussianNB implements Estimator, Learner, Online, Probabilistic, Persistab
 
     /**
      * @param (int|float)[]|null $priors
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(?array $priors = null)
     {
@@ -199,7 +199,7 @@ class GaussianNB implements Estimator, Learner, Online, Probabilistic, Persistab
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -212,7 +212,7 @@ class GaussianNB implements Estimator, Learner, Online, Probabilistic, Persistab
      * Perform a partial train on the learner.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function partial(Dataset $dataset) : void
     {
@@ -286,7 +286,7 @@ class GaussianNB implements Estimator, Learner, Online, Probabilistic, Persistab
      * choose the class with the highest likelihood as the prediction.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<string>
      */
     public function predict(Dataset $dataset) : array
@@ -306,7 +306,7 @@ class GaussianNB implements Estimator, Learner, Online, Probabilistic, Persistab
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float[]>
      */
     public function proba(Dataset $dataset) : array

--- a/src/Classifiers/KDNeighbors.php
+++ b/src/Classifiers/KDNeighbors.php
@@ -19,8 +19,8 @@ use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function Rubix\ML\argmax;
@@ -82,7 +82,7 @@ class KDNeighbors implements Estimator, Learner, Probabilistic, Persistable, Str
      * @param int $k
      * @param bool $weighted
      * @param \Rubix\ML\Graph\Trees\Spatial|null $tree
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $k = 5, bool $weighted = true, ?Spatial $tree = null)
     {
@@ -154,7 +154,7 @@ class KDNeighbors implements Estimator, Learner, Probabilistic, Persistable, Str
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -180,7 +180,7 @@ class KDNeighbors implements Estimator, Learner, Probabilistic, Persistable, Str
      * Make predictions from a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<string>
      */
     public function predict(Dataset $dataset) : array
@@ -216,7 +216,7 @@ class KDNeighbors implements Estimator, Learner, Probabilistic, Persistable, Str
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float[]>
      */
     public function proba(Dataset $dataset) : array

--- a/src/Classifiers/KNearestNeighbors.php
+++ b/src/Classifiers/KNearestNeighbors.php
@@ -20,8 +20,8 @@ use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function Rubix\ML\argmax;
@@ -95,7 +95,7 @@ class KNearestNeighbors implements Estimator, Learner, Online, Probabilistic, Pe
      * @param int $k
      * @param bool $weighted
      * @param \Rubix\ML\Kernels\Distance\Distance|null $kernel
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $k = 5, bool $weighted = true, ?Distance $kernel = null)
     {
@@ -157,7 +157,7 @@ class KNearestNeighbors implements Estimator, Learner, Online, Probabilistic, Pe
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -182,7 +182,7 @@ class KNearestNeighbors implements Estimator, Learner, Online, Probabilistic, Pe
      * Perform a partial train on the learner.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function partial(Dataset $dataset) : void
     {
@@ -205,7 +205,7 @@ class KNearestNeighbors implements Estimator, Learner, Online, Probabilistic, Pe
      * Make predictions from a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return string[]
      */
     public function predict(Dataset $dataset) : array
@@ -241,7 +241,7 @@ class KNearestNeighbors implements Estimator, Learner, Online, Probabilistic, Pe
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return array[]
      */
     public function proba(Dataset $dataset) : array

--- a/src/Classifiers/LogisticRegression.php
+++ b/src/Classifiers/LogisticRegression.php
@@ -31,8 +31,8 @@ use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\NeuralNet\CostFunctions\ClassificationLoss;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function is_nan;
@@ -135,7 +135,7 @@ class LogisticRegression implements Estimator, Learner, Online, Probabilistic, R
      * @param float $minChange
      * @param int $window
      * @param \Rubix\ML\NeuralNet\CostFunctions\ClassificationLoss|null $costFn
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         int $batchSize = 128,
@@ -254,7 +254,7 @@ class LogisticRegression implements Estimator, Learner, Online, Probabilistic, R
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -286,7 +286,7 @@ class LogisticRegression implements Estimator, Learner, Online, Probabilistic, R
      * Perform a partial train on the learner.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function partial(Dataset $dataset) : void
     {
@@ -385,7 +385,7 @@ class LogisticRegression implements Estimator, Learner, Online, Probabilistic, R
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float[]>
      */
     public function proba(Dataset $dataset) : array
@@ -415,7 +415,7 @@ class LogisticRegression implements Estimator, Learner, Online, Probabilistic, R
     /**
      * Return the normalized importance scores of each feature column of the training set.
      *
-     * @throws RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return float[]
      */
     public function featureImportances() : array

--- a/src/Classifiers/MultilayerPerceptron.php
+++ b/src/Classifiers/MultilayerPerceptron.php
@@ -35,8 +35,8 @@ use Rubix\ML\NeuralNet\CostFunctions\ClassificationLoss;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\EstimatorIsCompatibleWithMetric;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function is_nan;
@@ -178,7 +178,7 @@ class MultilayerPerceptron implements Estimator, Learner, Online, Probabilistic,
      * @param float $holdOut
      * @param \Rubix\ML\NeuralNet\CostFunctions\ClassificationLoss|null $costFn
      * @param \Rubix\ML\CrossValidation\Metrics\Metric|null $metric
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         array $hiddenLayers = [],
@@ -332,7 +332,7 @@ class MultilayerPerceptron implements Estimator, Learner, Online, Probabilistic,
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -368,8 +368,7 @@ class MultilayerPerceptron implements Estimator, Learner, Online, Probabilistic,
      * Train the network using mini-batch gradient descent with backpropagation.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function partial(Dataset $dataset) : void
     {
@@ -501,7 +500,7 @@ class MultilayerPerceptron implements Estimator, Learner, Online, Probabilistic,
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float[]>
      */
     public function proba(Dataset $dataset) : array

--- a/src/Classifiers/NaiveBayes.php
+++ b/src/Classifiers/NaiveBayes.php
@@ -19,8 +19,8 @@ use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function Rubix\ML\logsumexp;
@@ -100,7 +100,7 @@ class NaiveBayes implements Estimator, Learner, Online, Probabilistic, Persistab
     /**
      * @param float $smoothing
      * @param (int|float)[]|null $priors
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $smoothing = 1.0, ?array $priors = null)
     {
@@ -215,7 +215,7 @@ class NaiveBayes implements Estimator, Learner, Online, Probabilistic, Persistab
      * Perform a partial train on the learner.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function partial(Dataset $dataset) : void
     {
@@ -286,7 +286,7 @@ class NaiveBayes implements Estimator, Learner, Online, Probabilistic, Persistab
      * Make predictions from a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<string>
      */
     public function predict(Dataset $dataset) : array
@@ -306,7 +306,7 @@ class NaiveBayes implements Estimator, Learner, Online, Probabilistic, Persistab
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float[]>
      */
     public function proba(Dataset $dataset) : array

--- a/src/Classifiers/RadiusNeighbors.php
+++ b/src/Classifiers/RadiusNeighbors.php
@@ -19,8 +19,8 @@ use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function Rubix\ML\argmax;
@@ -90,7 +90,7 @@ class RadiusNeighbors implements Estimator, Learner, Probabilistic, Persistable,
      * @param bool $weighted
      * @param string $outlierClass
      * @param \Rubix\ML\Graph\Trees\Spatial|null $tree
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         float $radius = 1.0,
@@ -173,8 +173,8 @@ class RadiusNeighbors implements Estimator, Learner, Probabilistic, Persistable,
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function train(Dataset $dataset) : void
     {
@@ -209,7 +209,7 @@ class RadiusNeighbors implements Estimator, Learner, Probabilistic, Persistable,
      * Make predictions from a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<string>
      */
     public function predict(Dataset $dataset) : array
@@ -251,7 +251,7 @@ class RadiusNeighbors implements Estimator, Learner, Probabilistic, Persistable,
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float[]>
      */
     public function proba(Dataset $dataset) : array

--- a/src/Classifiers/RandomForest.php
+++ b/src/Classifiers/RandomForest.php
@@ -24,8 +24,8 @@ use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function Rubix\ML\argmax;
@@ -123,7 +123,7 @@ class RandomForest implements Estimator, Learner, Probabilistic, Parallel, Ranks
      * @param int $estimators
      * @param float $ratio
      * @param bool $balanced
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         ?Learner $base = null,
@@ -202,7 +202,7 @@ class RandomForest implements Estimator, Learner, Probabilistic, Parallel, Ranks
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -256,7 +256,7 @@ class RandomForest implements Estimator, Learner, Probabilistic, Parallel, Ranks
      * Make predictions from a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<string>
      */
     public function predict(Dataset $dataset) : array
@@ -288,7 +288,7 @@ class RandomForest implements Estimator, Learner, Probabilistic, Parallel, Ranks
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float[]>
      */
     public function proba(Dataset $dataset) : array
@@ -330,7 +330,7 @@ class RandomForest implements Estimator, Learner, Probabilistic, Parallel, Ranks
     /**
      * Return the normalized importance scores of each feature column of the training set.
      *
-     * @throws RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return float[]
      */
     public function featureImportances() : array

--- a/src/Classifiers/SVC.php
+++ b/src/Classifiers/SVC.php
@@ -16,8 +16,8 @@ use Rubix\ML\Other\Traits\PredictsSingle;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 use svmmodel;
 use svm;
@@ -79,8 +79,8 @@ class SVC implements Estimator, Learner, Stringable
      * @param bool $shrinking
      * @param float $tolerance
      * @param float $cacheSize
-     * @throws \RuntimeException
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         float $c = 1.0,
@@ -182,7 +182,7 @@ class SVC implements Estimator, Learner, Stringable
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -216,7 +216,7 @@ class SVC implements Estimator, Learner, Stringable
      * Make predictions from a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<string>
      */
     public function predict(Dataset $dataset) : array
@@ -238,7 +238,7 @@ class SVC implements Estimator, Learner, Stringable
      * Save the model data to the filesystem.
      *
      * @param string $path
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function save(string $path) : void
     {

--- a/src/Classifiers/SoftmaxClassifier.php
+++ b/src/Classifiers/SoftmaxClassifier.php
@@ -30,8 +30,8 @@ use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\NeuralNet\CostFunctions\ClassificationLoss;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function is_nan;
@@ -132,7 +132,7 @@ class SoftmaxClassifier implements Estimator, Learner, Online, Probabilistic, Ve
      * @param float $minChange
      * @param int $window
      * @param \Rubix\ML\NeuralNet\CostFunctions\ClassificationLoss|null $costFn
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         int $batchSize = 128,
@@ -251,7 +251,7 @@ class SoftmaxClassifier implements Estimator, Learner, Online, Probabilistic, Ve
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -283,7 +283,7 @@ class SoftmaxClassifier implements Estimator, Learner, Online, Probabilistic, Ve
      * Perform a partial train on the learner.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function partial(Dataset $dataset) : void
     {
@@ -382,7 +382,7 @@ class SoftmaxClassifier implements Estimator, Learner, Online, Probabilistic, Ve
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float[]>
      */
     public function proba(Dataset $dataset) : array

--- a/src/Clusterers/DBSCAN.php
+++ b/src/Clusterers/DBSCAN.php
@@ -13,7 +13,7 @@ use Rubix\ML\Other\Helpers\Verifier;
 use Rubix\ML\Kernels\Distance\Distance;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 use function count;
@@ -77,7 +77,7 @@ class DBSCAN implements Estimator, Stringable
      * @param float $radius
      * @param int $minDensity
      * @param \Rubix\ML\Graph\Trees\Spatial|null $tree
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $radius = 0.5, int $minDensity = 5, ?Spatial $tree = null)
     {

--- a/src/Clusterers/FuzzyCMeans.php
+++ b/src/Clusterers/FuzzyCMeans.php
@@ -22,8 +22,8 @@ use Rubix\ML\Clusterers\Seeders\PlusPlus;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function count;
@@ -123,7 +123,7 @@ class FuzzyCMeans implements Estimator, Learner, Probabilistic, Verbose, Persist
      * @param float $minChange
      * @param \Rubix\ML\Kernels\Distance\Distance|null $kernel
      * @param \Rubix\ML\Clusterers\Seeders\Seeder|null $seeder
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         int $c,
@@ -326,7 +326,7 @@ class FuzzyCMeans implements Estimator, Learner, Probabilistic, Verbose, Persist
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float[]>
      */
     public function proba(Dataset $dataset) : array

--- a/src/Clusterers/GaussianMixture.php
+++ b/src/Clusterers/GaussianMixture.php
@@ -22,8 +22,8 @@ use Rubix\ML\Clusterers\Seeders\PlusPlus;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function Rubix\ML\logsumexp;
@@ -125,7 +125,7 @@ class GaussianMixture implements Estimator, Learner, Probabilistic, Verbose, Per
      * @param int $epochs
      * @param float $minChange
      * @param \Rubix\ML\Clusterers\Seeders\Seeder|null $seeder
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         int $k,
@@ -359,7 +359,7 @@ class GaussianMixture implements Estimator, Learner, Probabilistic, Verbose, Per
      * Make predictions from a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<int>
      */
     public function predict(Dataset $dataset) : array
@@ -379,7 +379,7 @@ class GaussianMixture implements Estimator, Learner, Probabilistic, Verbose, Per
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float[]>
      */
     public function proba(Dataset $dataset) : array

--- a/src/Clusterers/KMeans.php
+++ b/src/Clusterers/KMeans.php
@@ -25,8 +25,8 @@ use Rubix\ML\Clusterers\Seeders\PlusPlus;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function count;
@@ -139,7 +139,7 @@ class KMeans implements Estimator, Learner, Online, Probabilistic, Verbose, Pers
      * @param int $window
      * @param \Rubix\ML\Kernels\Distance\Distance|null $kernel
      * @param \Rubix\ML\Clusterers\Seeders\Seeder|null $seeder
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         int $k,
@@ -406,7 +406,7 @@ class KMeans implements Estimator, Learner, Online, Probabilistic, Verbose, Pers
      * Cluster the dataset by assigning a label to each sample.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<int>
      */
     public function predict(Dataset $dataset) : array
@@ -424,7 +424,7 @@ class KMeans implements Estimator, Learner, Online, Probabilistic, Verbose, Pers
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float[]>
      */
     public function proba(Dataset $dataset) : array

--- a/src/Clusterers/MeanShift.php
+++ b/src/Clusterers/MeanShift.php
@@ -26,8 +26,8 @@ use Rubix\ML\Other\Traits\PredictsSingle;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function Rubix\ML\array_transpose;
@@ -139,7 +139,7 @@ class MeanShift implements Estimator, Learner, Probabilistic, Verbose, Persistab
      * @param \Rubix\ML\Datasets\Dataset $dataset
      * @param float $percentile
      * @param \Rubix\ML\Kernels\Distance\Distance|null $kernel
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public static function estimateRadius(
@@ -176,7 +176,7 @@ class MeanShift implements Estimator, Learner, Probabilistic, Verbose, Persistab
      * @param float $minShift
      * @param \Rubix\ML\Graph\Trees\Spatial|null $tree
      * @param \Rubix\ML\Clusterers\Seeders\Seeder|null $seeder
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         float $radius,
@@ -379,7 +379,7 @@ class MeanShift implements Estimator, Learner, Probabilistic, Verbose, Persistab
      * Cluster the dataset by assigning a label to each sample.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<int>
      */
     public function predict(Dataset $dataset) : array
@@ -397,7 +397,7 @@ class MeanShift implements Estimator, Learner, Probabilistic, Verbose, Persistab
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<float[]>
      */
     public function proba(Dataset $dataset) : array

--- a/src/Clusterers/Seeders/KMC2.php
+++ b/src/Clusterers/Seeders/KMC2.php
@@ -6,7 +6,7 @@ use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Kernels\Distance\Distance;
 use Rubix\ML\Kernels\Distance\Euclidean;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 use function count;
@@ -45,7 +45,7 @@ class KMC2 implements Seeder, Stringable
     /**
      * @param int $m
      * @param \Rubix\ML\Kernels\Distance\Distance|null $kernel
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $m = 50, ?Distance $kernel = null)
     {

--- a/src/CommitteeMachine.php
+++ b/src/CommitteeMachine.php
@@ -15,8 +15,8 @@ use Rubix\ML\Backends\Tasks\TrainLearner;
 use Rubix\ML\Other\Traits\Multiprocessing;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function count;
@@ -87,7 +87,7 @@ class CommitteeMachine implements Estimator, Learner, Parallel, Verbose, Persist
     /**
      * @param \Rubix\ML\Learner[] $experts
      * @param (int|float)[]|null $influences
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(array $experts, ?array $influences = null)
     {
@@ -224,7 +224,7 @@ class CommitteeMachine implements Estimator, Learner, Parallel, Verbose, Persist
      * Train all the experts with the dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -280,7 +280,7 @@ class CommitteeMachine implements Estimator, Learner, Parallel, Verbose, Persist
      * The callback that executes after the training task.
      *
      * @param \Rubix\ML\Learner $estimator
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function afterTrain(Learner $estimator) : void
     {

--- a/src/CrossValidation/HoldOut.php
+++ b/src/CrossValidation/HoldOut.php
@@ -7,8 +7,8 @@ use Rubix\ML\Estimator;
 use Rubix\ML\Datasets\Labeled;
 use Rubix\ML\CrossValidation\Metrics\Metric;
 use Rubix\ML\Specifications\EstimatorIsCompatibleWithMetric;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 /**
@@ -34,7 +34,7 @@ class HoldOut implements Validator, Stringable
 
     /**
      * @param float $ratio
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $ratio = 0.2)
     {
@@ -52,7 +52,7 @@ class HoldOut implements Validator, Stringable
      * @param \Rubix\ML\Learner $estimator
      * @param \Rubix\ML\Datasets\Labeled $dataset
      * @param \Rubix\ML\CrossValidation\Metrics\Metric $metric
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return float
      */
     public function test(Learner $estimator, Labeled $dataset, Metric $metric) : float

--- a/src/CrossValidation/KFold.php
+++ b/src/CrossValidation/KFold.php
@@ -13,7 +13,7 @@ use Rubix\ML\Other\Traits\Multiprocessing;
 use Rubix\ML\CrossValidation\Metrics\Metric;
 use Rubix\ML\Backends\Tasks\TrainAndValidate;
 use Rubix\ML\Specifications\EstimatorIsCompatibleWithMetric;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 /**
@@ -42,7 +42,7 @@ class KFold implements Validator, Parallel, Stringable
 
     /**
      * @param int $k
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $k = 5)
     {
@@ -61,7 +61,7 @@ class KFold implements Validator, Parallel, Stringable
      * @param \Rubix\ML\Learner $estimator
      * @param \Rubix\ML\Datasets\Labeled $dataset
      * @param \Rubix\ML\CrossValidation\Metrics\Metric $metric
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public function test(Learner $estimator, Labeled $dataset, Metric $metric) : float

--- a/src/CrossValidation/LeavePOut.php
+++ b/src/CrossValidation/LeavePOut.php
@@ -13,7 +13,7 @@ use Rubix\ML\Other\Traits\Multiprocessing;
 use Rubix\ML\CrossValidation\Metrics\Metric;
 use Rubix\ML\Backends\Tasks\TrainAndValidate;
 use Rubix\ML\Specifications\EstimatorIsCompatibleWithMetric;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 /**
@@ -40,7 +40,7 @@ class LeavePOut implements Validator, Parallel, Stringable
 
     /**
      * @param int $p
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $p = 10)
     {
@@ -59,7 +59,7 @@ class LeavePOut implements Validator, Parallel, Stringable
      * @param \Rubix\ML\Learner $estimator
      * @param \Rubix\ML\Datasets\Labeled $dataset
      * @param \Rubix\ML\CrossValidation\Metrics\Metric $metric
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public function test(Learner $estimator, Labeled $dataset, Metric $metric) : float

--- a/src/CrossValidation/Metrics/FBeta.php
+++ b/src/CrossValidation/Metrics/FBeta.php
@@ -6,7 +6,7 @@ use Rubix\ML\Estimator;
 use Rubix\ML\EstimatorType;
 use Rubix\ML\Other\Helpers\Stats;
 use Rubix\ML\Specifications\PredictionAndLabelCountsAreEqual;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 use function count;
@@ -60,7 +60,7 @@ class FBeta implements Metric, Stringable
 
     /**
      * @param float $beta
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $beta = 1.0)
     {

--- a/src/CrossValidation/Metrics/Homogeneity.php
+++ b/src/CrossValidation/Metrics/Homogeneity.php
@@ -55,7 +55,7 @@ class Homogeneity implements Metric, Stringable
      *
      * @param list<string|int> $predictions
      * @param list<string|int> $labels
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public function score(array $predictions, array $labels) : float

--- a/src/CrossValidation/Metrics/MCC.php
+++ b/src/CrossValidation/Metrics/MCC.php
@@ -72,7 +72,7 @@ class MCC implements Metric, Stringable
      *
      * @param list<string|int> $predictions
      * @param list<string|int> $labels
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public function score(array $predictions, array $labels) : float

--- a/src/CrossValidation/Metrics/MeanAbsoluteError.php
+++ b/src/CrossValidation/Metrics/MeanAbsoluteError.php
@@ -52,7 +52,7 @@ class MeanAbsoluteError implements Metric, Stringable
      *
      * @param list<int|float> $predictions
      * @param list<int|float> $labels
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public function score(array $predictions, array $labels) : float

--- a/src/CrossValidation/Metrics/MeanSquaredError.php
+++ b/src/CrossValidation/Metrics/MeanSquaredError.php
@@ -52,7 +52,7 @@ class MeanSquaredError implements Metric, Stringable
      *
      * @param list<int|float> $predictions
      * @param list<int|float> $labels
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public function score(array $predictions, array $labels) : float

--- a/src/CrossValidation/Metrics/MedianAbsoluteError.php
+++ b/src/CrossValidation/Metrics/MedianAbsoluteError.php
@@ -51,7 +51,7 @@ class MedianAbsoluteError implements Metric, Stringable
      *
      * @param list<int|float> $predictions
      * @param list<int|float> $labels
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public function score(array $predictions, array $labels) : float

--- a/src/CrossValidation/Metrics/VMeasure.php
+++ b/src/CrossValidation/Metrics/VMeasure.php
@@ -4,7 +4,7 @@ namespace Rubix\ML\CrossValidation\Metrics;
 
 use Rubix\ML\Estimator;
 use Rubix\ML\EstimatorType;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 use const Rubix\ML\EPSILON;
@@ -35,7 +35,7 @@ class VMeasure implements Metric, Stringable
 
     /**
      * @param float $beta
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $beta = 1.0)
     {

--- a/src/CrossValidation/MonteCarlo.php
+++ b/src/CrossValidation/MonteCarlo.php
@@ -13,8 +13,8 @@ use Rubix\ML\Other\Traits\Multiprocessing;
 use Rubix\ML\CrossValidation\Metrics\Metric;
 use Rubix\ML\Backends\Tasks\TrainAndValidate;
 use Rubix\ML\Specifications\EstimatorIsCompatibleWithMetric;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 /**
@@ -52,7 +52,7 @@ class MonteCarlo implements Validator, Parallel, Stringable
     /**
      * @param int $simulations
      * @param float $ratio
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $simulations = 10, float $ratio = 0.2)
     {
@@ -77,7 +77,7 @@ class MonteCarlo implements Validator, Parallel, Stringable
      * @param \Rubix\ML\Learner $estimator
      * @param \Rubix\ML\Datasets\Labeled $dataset
      * @param \Rubix\ML\CrossValidation\Metrics\Metric $metric
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return float
      */
     public function test(Learner $estimator, Labeled $dataset, Metric $metric) : float

--- a/src/CrossValidation/Reports/AggregateReport.php
+++ b/src/CrossValidation/Reports/AggregateReport.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\CrossValidation\Reports;
 
 use Rubix\ML\Report;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 use function count;
 
@@ -37,7 +37,7 @@ class AggregateReport implements ReportGenerator
 
     /**
      * @param \Rubix\ML\CrossValidation\Reports\ReportGenerator[] $reports
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(array $reports)
     {

--- a/src/DataType.php
+++ b/src/DataType.php
@@ -2,7 +2,7 @@
 
 namespace Rubix\ML;
 
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 use function gettype;
@@ -169,7 +169,7 @@ class DataType implements Stringable
 
     /**
      * @param int $code
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $code)
     {

--- a/src/Datasets/Dataset.php
+++ b/src/Datasets/Dataset.php
@@ -10,10 +10,10 @@ use Rubix\ML\Other\Helpers\Stats;
 use Rubix\ML\Transformers\Stateful;
 use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Kernels\Distance\Distance;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use IteratorAggregate;
 use JsonSerializable;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use ArrayAccess;
 use Stringable;
 use Countable;
@@ -72,7 +72,7 @@ abstract class Dataset implements ArrayAccess, IteratorAggregate, JsonSerializab
     /**
      * @param array[] $samples
      * @param bool $verify
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(array $samples = [], bool $verify = true)
     {
@@ -199,8 +199,8 @@ abstract class Dataset implements ArrayAccess, IteratorAggregate, JsonSerializab
      * Get the datatype for a feature column at the given offset.
      *
      * @param int $offset
-     * @throws \InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Rubix\ML\DataType
      */
     public function columnType(int $offset) : DataType
@@ -274,7 +274,7 @@ abstract class Dataset implements ArrayAccess, IteratorAggregate, JsonSerializab
      *
      * @param int $offset
      * @param callable $callback
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function transformColumn(int $offset, callable $callback) : self
@@ -309,7 +309,7 @@ abstract class Dataset implements ArrayAccess, IteratorAggregate, JsonSerializab
      * Drop the columns at the given offsets.
      *
      * @param int[] $offsets
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function dropColumns(array $offsets) : self
@@ -396,7 +396,7 @@ abstract class Dataset implements ArrayAccess, IteratorAggregate, JsonSerializab
      * @param string[]|null $header
      * @param string $delimiter
      * @param string $enclosure
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return \Rubix\ML\Encoding
      */
     public function toCSV(?array $header = null, string $delimiter = ',', string $enclosure = '"') : Encoding
@@ -753,7 +753,7 @@ abstract class Dataset implements ArrayAccess, IteratorAggregate, JsonSerializab
     /**
      * @param int $offset
      * @param mixed[] $values
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function offsetSet($offset, $values) : void
     {
@@ -773,7 +773,7 @@ abstract class Dataset implements ArrayAccess, IteratorAggregate, JsonSerializab
 
     /**
      * @param int $offset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function offsetUnset($offset) : void
     {

--- a/src/Datasets/Generators/Agglomerate.php
+++ b/src/Datasets/Generators/Agglomerate.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\Datasets\Generators;
 
 use Rubix\ML\Datasets\Labeled;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 use function count;
 
@@ -46,7 +46,7 @@ class Agglomerate implements Generator
     /**
      * @param \Rubix\ML\Datasets\Generators\Generator[] $generators
      * @param (int|float)[]|null $weights
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(array $generators = [], ?array $weights = null)
     {

--- a/src/Datasets/Generators/Blob.php
+++ b/src/Datasets/Generators/Blob.php
@@ -5,7 +5,7 @@ namespace Rubix\ML\Datasets\Generators;
 use Tensor\Matrix;
 use Tensor\Vector;
 use Rubix\ML\Datasets\Unlabeled;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 use function count;
 
@@ -40,7 +40,7 @@ class Blob implements Generator
     /**
      * @param (int|float)[] $center
      * @param int|float|(int|float)[] $stdDev
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(array $center = [0, 0], $stdDev = 1.0)
     {

--- a/src/Datasets/Generators/Circle.php
+++ b/src/Datasets/Generators/Circle.php
@@ -6,7 +6,7 @@ use Tensor\Matrix;
 use Tensor\Vector;
 use Tensor\ColumnVector;
 use Rubix\ML\Datasets\Labeled;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 use const Rubix\ML\TWO_PI;
 
@@ -47,7 +47,7 @@ class Circle implements Generator
      * @param float $y
      * @param float $scale
      * @param float $noise
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         float $x = 0.0,

--- a/src/Datasets/Generators/HalfMoon.php
+++ b/src/Datasets/Generators/HalfMoon.php
@@ -6,7 +6,7 @@ use Tensor\Matrix;
 use Tensor\Vector;
 use Tensor\ColumnVector;
 use Rubix\ML\Datasets\Labeled;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 /**
  * Half Moon
@@ -54,7 +54,7 @@ class HalfMoon implements Generator
      * @param float $scale
      * @param float $rotation
      * @param float $noise
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         float $x = 0.0,

--- a/src/Datasets/Generators/Hyperplane.php
+++ b/src/Datasets/Generators/Hyperplane.php
@@ -5,7 +5,7 @@ namespace Rubix\ML\Datasets\Generators;
 use Tensor\Matrix;
 use Tensor\Vector;
 use Rubix\ML\Datasets\Labeled;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 /**
  * Hyperplane
@@ -47,7 +47,7 @@ class Hyperplane implements Generator
      * @param (int|float)[] $coefficients
      * @param float $intercept
      * @param float $noise
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         array $coefficients = [1, -1],

--- a/src/Datasets/Generators/SwissRoll.php
+++ b/src/Datasets/Generators/SwissRoll.php
@@ -6,7 +6,7 @@ use Tensor\Matrix;
 use Tensor\Vector;
 use Tensor\ColumnVector;
 use Rubix\ML\Datasets\Labeled;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 use const Rubix\ML\HALF_PI;
 
@@ -62,7 +62,7 @@ class SwissRoll implements Generator
      * @param float $scale
      * @param float $depth
      * @param float $noise
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         float $x = 0.0,

--- a/src/Datasets/Labeled.php
+++ b/src/Datasets/Labeled.php
@@ -8,8 +8,8 @@ use Rubix\ML\Other\Helpers\Stats;
 use Rubix\ML\Other\Helpers\Console;
 use Rubix\ML\Kernels\Distance\Distance;
 use Rubix\ML\Kernels\Distance\Euclidean;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use ErrorException;
 use Generator;
 
@@ -96,7 +96,7 @@ class Labeled extends Dataset
      * Stack a number of datasets on top of each other to form a single dataset.
      *
      * @param \Rubix\ML\Datasets\Labeled[] $datasets
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public static function stack(array $datasets) : self
@@ -132,7 +132,7 @@ class Labeled extends Dataset
      * @param array[] $samples
      * @param (string|int|float)[] $labels
      * @param bool $verify
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(array $samples = [], array $labels = [], bool $verify = true)
     {
@@ -185,7 +185,7 @@ class Labeled extends Dataset
      * Return a label at the given row offset.
      *
      * @param int $offset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return int|float|string
      */
     public function label(int $offset)
@@ -200,7 +200,7 @@ class Labeled extends Dataset
     /**
      * Return the integer encoded data type of the label or null if empty.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Rubix\ML\DataType
      */
     public function labelType() : DataType
@@ -216,7 +216,7 @@ class Labeled extends Dataset
      * Map labels to their new values and return self for method chaining.
      *
      * @param callable $callback
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return self
      */
     public function transformLabels(callable $callback) : self
@@ -249,7 +249,7 @@ class Labeled extends Dataset
      * Return a dataset containing only the first n samples.
      *
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function head(int $n = 10) : self
@@ -266,7 +266,7 @@ class Labeled extends Dataset
      * Return a dataset containing only the last n samples.
      *
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function tail(int $n = 10) : self
@@ -284,7 +284,7 @@ class Labeled extends Dataset
      * dataset.
      *
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function take(int $n = 1) : self
@@ -302,7 +302,7 @@ class Labeled extends Dataset
      * dataset.
      *
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function leave(int $n = 1) : self
@@ -350,7 +350,7 @@ class Labeled extends Dataset
      * Merge the rows of this dataset with another dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function merge(Dataset $dataset) : self
@@ -378,7 +378,7 @@ class Labeled extends Dataset
      * Join the columns of this dataset with another dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function join(Dataset $dataset) : self
@@ -428,7 +428,7 @@ class Labeled extends Dataset
      * Drop the rows at the given indices.
      *
      * @param int[] $offsets
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function dropRows(array $offsets) : self
@@ -568,7 +568,7 @@ class Labeled extends Dataset
      * Split the dataset into two subsets with a given ratio of samples.
      *
      * @param float $ratio
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return array{self,self}
      */
     public function split(float $ratio = 0.5) : array
@@ -596,7 +596,7 @@ class Labeled extends Dataset
      * Split the dataset into two stratified subsets with a given ratio of samples.
      *
      * @param float $ratio
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return array{self,self}
      */
     public function stratifiedSplit(float $ratio = 0.5) : array
@@ -634,7 +634,7 @@ class Labeled extends Dataset
      * Fold the dataset k - 1 times to form k equal size datasets.
      *
      * @param int $k
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return list<self>
      */
     public function fold(int $k = 10) : array
@@ -665,7 +665,7 @@ class Labeled extends Dataset
      * Fold the dataset into k equal sized stratified datasets.
      *
      * @param int $k
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return list<self>
      */
     public function stratifiedFold(int $k = 10) : array
@@ -719,7 +719,7 @@ class Labeled extends Dataset
      *
      * @param int $column
      * @param string|int|float $value
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return array{self,self}
      */
     public function partitionByColumn(int $column, $value) : array
@@ -761,7 +761,7 @@ class Labeled extends Dataset
      * @param (string|int|float)[] $leftCentroid
      * @param (string|int|float)[] $rightCentroid
      * @param \Rubix\ML\Kernels\Distance\Distance|null $kernel
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return array{self,self}
      */
     public function spatialPartition(array $leftCentroid, array $rightCentroid, ?Distance $kernel = null)
@@ -805,7 +805,7 @@ class Labeled extends Dataset
      * Generate a random subset without replacement.
      *
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function randomSubset(int $n) : self
@@ -838,7 +838,7 @@ class Labeled extends Dataset
      * Generate a random subset with replacement.
      *
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function randomSubsetWithReplacement(int $n) : self
@@ -867,7 +867,7 @@ class Labeled extends Dataset
      *
      * @param int $n
      * @param (int|float)[] $weights
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function randomWeightedSubsetWithReplacement(int $n, array $weights) : self
@@ -1026,7 +1026,7 @@ class Labeled extends Dataset
      * Return a row from the dataset at the given offset.
      *
      * @param int $offset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return mixed[]
      */
     public function offsetGet($offset) : array
@@ -1056,7 +1056,7 @@ class Labeled extends Dataset
      * Stratifying subroutine groups samples by their categorical label. Note that integer string
      * labels will silently be converted to integers by PHP.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return array[]
      */
     protected function _stratify() : array

--- a/src/Datasets/Unlabeled.php
+++ b/src/Datasets/Unlabeled.php
@@ -5,7 +5,7 @@ namespace Rubix\ML\Datasets;
 use Rubix\ML\Other\Helpers\Console;
 use Rubix\ML\Kernels\Distance\Distance;
 use Rubix\ML\Kernels\Distance\Euclidean;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Generator;
 
 use function Rubix\ML\warn_deprecated;
@@ -65,7 +65,7 @@ class Unlabeled extends Dataset
      * dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset[] $datasets
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public static function stack(array $datasets) : self
@@ -96,7 +96,7 @@ class Unlabeled extends Dataset
      * Return a dataset containing only the first n samples.
      *
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function head(int $n = 10) : self
@@ -113,7 +113,7 @@ class Unlabeled extends Dataset
      * Return a dataset containing only the last n samples.
      *
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function tail(int $n = 10) : self
@@ -130,7 +130,7 @@ class Unlabeled extends Dataset
      * Take n samples from this dataset and return them in a new dataset.
      *
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function take(int $n = 1) : self
@@ -147,7 +147,7 @@ class Unlabeled extends Dataset
      * Leave n samples on this dataset and return the rest in a new dataset.
      *
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function leave(int $n = 1) : self
@@ -189,7 +189,7 @@ class Unlabeled extends Dataset
      * Merge another dataset with this dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function merge(Dataset $dataset) : self
@@ -209,7 +209,7 @@ class Unlabeled extends Dataset
      * Join the columns of this dataset with another dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function join(Dataset $dataset) : self
@@ -259,7 +259,7 @@ class Unlabeled extends Dataset
      * Drop the rows at the given indices.
      *
      * @param int[] $offsets
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function dropRows(array $offsets) : self
@@ -326,7 +326,7 @@ class Unlabeled extends Dataset
      * Split the dataset into two stratified subsets with a given ratio of samples.
      *
      * @param float $ratio
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return array{self,self}
      */
     public function split(float $ratio = 0.5) : array
@@ -348,7 +348,7 @@ class Unlabeled extends Dataset
      * Fold the dataset k - 1 times to form k equal size datasets.
      *
      * @param int $k
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return list<self>
      */
     public function fold(int $k = 3) : array
@@ -390,7 +390,7 @@ class Unlabeled extends Dataset
      *
      * @param int $column
      * @param string|int|float $value
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return array{self,self}
      */
     public function partitionByColumn(int $column, $value) : array
@@ -425,7 +425,7 @@ class Unlabeled extends Dataset
      * @param (string|int|float)[] $leftCentroid
      * @param (string|int|float)[] $rightCentroid
      * @param \Rubix\ML\Kernels\Distance\Distance|null $kernel
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return array{self,self}
      */
     public function spatialPartition(array $leftCentroid, array $rightCentroid, ?Distance $kernel = null)
@@ -464,7 +464,7 @@ class Unlabeled extends Dataset
      * Generate a random subset without replacement.
      *
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function randomSubset(int $n) : self
@@ -496,7 +496,7 @@ class Unlabeled extends Dataset
      * Generate a random subset with replacement.
      *
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function randomSubsetWithReplacement(int $n) : self
@@ -522,7 +522,7 @@ class Unlabeled extends Dataset
      *
      * @param int $n
      * @param (int|float)[] $weights
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return self
      */
     public function randomWeightedSubsetWithReplacement(int $n, array $weights) : self
@@ -602,7 +602,7 @@ class Unlabeled extends Dataset
      * Return a row from the dataset at the given offset.
      *
      * @param int $offset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return array[]
      */
     public function offsetGet($offset) : array

--- a/src/Embedders/TSNE.php
+++ b/src/Embedders/TSNE.php
@@ -12,7 +12,7 @@ use Rubix\ML\Other\Traits\LoggerAware;
 use Rubix\ML\Kernels\Distance\Distance;
 use Rubix\ML\Kernels\Distance\Euclidean;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 use const Rubix\ML\EPSILON;
@@ -213,7 +213,7 @@ class TSNE implements Embedder, Verbose, Stringable
      * @param float $minGradient
      * @param int $window
      * @param \Rubix\ML\Kernels\Distance\Distance|null $kernel
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         int $dimensions = 2,

--- a/src/Encoding.php
+++ b/src/Encoding.php
@@ -2,7 +2,7 @@
 
 namespace Rubix\ML;
 
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 class Encoding implements Stringable
@@ -46,7 +46,7 @@ class Encoding implements Stringable
      * Write the encoding to a file at the path specified.
      *
      * @param string $path
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function write(string $path) : void
     {

--- a/src/EstimatorType.php
+++ b/src/EstimatorType.php
@@ -2,7 +2,7 @@
 
 namespace Rubix\ML;
 
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 use function in_array;
@@ -129,7 +129,7 @@ class EstimatorType implements Stringable
 
     /**
      * @param int $code
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $code)
     {

--- a/src/Exceptions/InvalidArgumentException.php
+++ b/src/Exceptions/InvalidArgumentException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rubix\ML\Exceptions;
+
+class InvalidArgumentException extends \InvalidArgumentException implements RubixMLException
+{
+}

--- a/src/Exceptions/RubixMLException.php
+++ b/src/Exceptions/RubixMLException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rubix\ML\Exceptions;
+
+interface RubixMLException extends \Throwable
+{
+}

--- a/src/Exceptions/RuntimeException.php
+++ b/src/Exceptions/RuntimeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rubix\ML\Exceptions;
+
+class RuntimeException extends \RuntimeException implements RubixMLException
+{
+}

--- a/src/Extractors/CSV.php
+++ b/src/Extractors/CSV.php
@@ -2,8 +2,8 @@
 
 namespace Rubix\ML\Extractors;
 
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Generator;
 
 use function strlen;
@@ -61,8 +61,8 @@ class CSV implements Extractor
      * @param bool $header
      * @param string $delimiter
      * @param string $enclosure
-     * @throws \InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function __construct(
         string $path,
@@ -111,7 +111,7 @@ class CSV implements Extractor
     /**
      * Return an iterator for the records in the data table.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Generator<mixed[]>
      */
     public function getIterator() : Generator

--- a/src/Extractors/ColumnPicker.php
+++ b/src/Extractors/ColumnPicker.php
@@ -2,7 +2,7 @@
 
 namespace Rubix\ML\Extractors;
 
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Generator;
 
 /**

--- a/src/Extractors/JSON.php
+++ b/src/Extractors/JSON.php
@@ -2,8 +2,8 @@
 
 namespace Rubix\ML\Extractors;
 
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Generator;
 use Rubix\ML\Other\Helpers\JSON as JSONHelper;
 
@@ -32,7 +32,7 @@ class JSON implements Extractor
 
     /**
      * @param string $path
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(string $path)
     {
@@ -50,7 +50,7 @@ class JSON implements Extractor
     /**
      * Return an iterator for the records in the data table.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Generator<mixed[]>
      */
     public function getIterator() : Generator

--- a/src/Extractors/NDJSON.php
+++ b/src/Extractors/NDJSON.php
@@ -2,8 +2,8 @@
 
 namespace Rubix\ML\Extractors;
 
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Generator;
 use Rubix\ML\Other\Helpers\JSON;
 
@@ -31,8 +31,8 @@ class NDJSON implements Extractor
 
     /**
      * @param string $path
-     * @throws \InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function __construct(string $path)
     {
@@ -64,7 +64,7 @@ class NDJSON implements Extractor
     /**
      * Return an iterator for the records in the data table.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Generator<mixed[]>
      */
     public function getIterator() : Generator

--- a/src/Graph/Nodes/Best.php
+++ b/src/Graph/Nodes/Best.php
@@ -50,7 +50,7 @@ class Best implements Outcome, Leaf
      * @param (int|float)[] $probabilities
      * @param float $impurity
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(string $outcome, array $probabilities, float $impurity, int $n)
     {

--- a/src/Graph/Nodes/Comparison.php
+++ b/src/Graph/Nodes/Comparison.php
@@ -59,7 +59,7 @@ class Comparison implements Decision
      * @param \Rubix\ML\Datasets\Labeled[] $groups
      * @param float $impurity
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $column, $value, array $groups, float $impurity, int $n)
     {

--- a/src/Graph/Nodes/Depth.php
+++ b/src/Graph/Nodes/Depth.php
@@ -63,7 +63,7 @@ class Depth implements BinaryNode, Leaf
 
     /**
      * @param float $depth
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $depth)
     {

--- a/src/Graph/Nodes/Isolator.php
+++ b/src/Graph/Nodes/Isolator.php
@@ -75,7 +75,7 @@ class Isolator implements BinaryNode
      * @param int $column
      * @param string|int|float $value
      * @param array{Dataset,Dataset} $groups
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $column, $value, array $groups)
     {

--- a/src/Graph/Trees/BallTree.php
+++ b/src/Graph/Trees/BallTree.php
@@ -9,7 +9,7 @@ use Rubix\ML\Graph\Nodes\Clique;
 use Rubix\ML\Graph\Nodes\Hypersphere;
 use Rubix\ML\Kernels\Distance\Distance;
 use Rubix\ML\Kernels\Distance\Euclidean;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use SplObjectStorage;
 use Stringable;
 
@@ -60,7 +60,7 @@ class BallTree implements BinaryTree, Spatial, Stringable
     /**
      * @param int $maxLeafSize
      * @param \Rubix\ML\Kernels\Distance\Distance|null $kernel
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $maxLeafSize = 30, ?Distance $kernel = null)
     {
@@ -120,7 +120,7 @@ class BallTree implements BinaryTree, Spatial, Stringable
      * condition is met.
      *
      * @param \Rubix\ML\Datasets\Labeled $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function grow(Labeled $dataset) : void
     {
@@ -168,7 +168,7 @@ class BallTree implements BinaryTree, Spatial, Stringable
      *
      * @param list<string|int|float> $sample
      * @param int $k
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return array{array[],mixed[],float[]}
      */
     public function nearest(array $sample, int $k = 1) : array
@@ -239,8 +239,8 @@ class BallTree implements BinaryTree, Spatial, Stringable
      *
      * @param list<string|int|float> $sample
      * @param float $radius
-     * @throws \InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return array{array[],mixed[],float[]}
      */
     public function range(array $sample, float $radius) : array

--- a/src/Graph/Trees/CART.php
+++ b/src/Graph/Trees/CART.php
@@ -8,8 +8,8 @@ use Rubix\ML\Graph\Nodes\Outcome;
 use Rubix\ML\Other\Helpers\Stats;
 use Rubix\ML\Graph\Nodes\Comparison;
 use Rubix\ML\Graph\Nodes\BinaryNode;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Generator;
 
 use function array_slice;
@@ -106,7 +106,7 @@ abstract class CART
      * @param int $maxLeafSize
      * @param int|null $maxFeatures
      * @param float $minPurityIncrease
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         int $maxHeight,
@@ -178,7 +178,7 @@ abstract class CART
      * condition is met.
      *
      * @param \Rubix\ML\Datasets\Labeled $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function grow(Labeled $dataset) : void
     {
@@ -298,7 +298,7 @@ abstract class CART
     /**
      * Return the normalized importance scores of each feature column of the training set.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return float[]
      */
     public function featureImportances() : array
@@ -328,7 +328,7 @@ abstract class CART
      * Print a human readable text representation of the decision tree.
      *
      * @param string[] $header
-     * @throws RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return string
      */
     public function rules(?array $header = null) : string

--- a/src/Graph/Trees/ITree.php
+++ b/src/Graph/Trees/ITree.php
@@ -5,7 +5,7 @@ namespace Rubix\ML\Graph\Trees;
 use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Graph\Nodes\Depth;
 use Rubix\ML\Graph\Nodes\Isolator;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 /**
  * I-Tree
@@ -45,7 +45,7 @@ class ITree implements BinaryTree
 
     /**
      * @param int $maxHeight
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $maxHeight = PHP_INT_MAX)
     {

--- a/src/Graph/Trees/KDTree.php
+++ b/src/Graph/Trees/KDTree.php
@@ -10,7 +10,7 @@ use Rubix\ML\Graph\Nodes\Hypercube;
 use Rubix\ML\Graph\Nodes\Neighborhood;
 use Rubix\ML\Kernels\Distance\Distance;
 use Rubix\ML\Kernels\Distance\Euclidean;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use SplObjectStorage;
 use Stringable;
 
@@ -59,7 +59,7 @@ class KDTree implements BinaryTree, Spatial, Stringable
     /**
      * @param int $maxLeafSize
      * @param \Rubix\ML\Kernels\Distance\Distance|null $kernel
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $maxLeafSize = 30, ?Distance $kernel = null)
     {
@@ -124,7 +124,7 @@ class KDTree implements BinaryTree, Spatial, Stringable
      * condition is met.
      *
      * @param \Rubix\ML\Datasets\Labeled $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function grow(Labeled $dataset) : void
     {
@@ -177,7 +177,7 @@ class KDTree implements BinaryTree, Spatial, Stringable
      *
      * @param list<int|float> $sample
      * @param int $k
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return array{array[],mixed[],float[]}
      */
     public function nearest(array $sample, int $k = 1) : array
@@ -251,7 +251,7 @@ class KDTree implements BinaryTree, Spatial, Stringable
      *
      * @param list<int|float> $sample
      * @param float $radius
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return array{array[],mixed[],float[]}
      */
     public function range(array $sample, float $radius) : array

--- a/src/GridSearch.php
+++ b/src/GridSearch.php
@@ -21,7 +21,7 @@ use Rubix\ML\CrossValidation\Metrics\VMeasure;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\EstimatorIsCompatibleWithMetric;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 use function count;
@@ -118,7 +118,7 @@ class GridSearch implements Estimator, Learner, Parallel, Verbose, Wrapper, Pers
      * @param array[] $params
      * @param \Rubix\ML\CrossValidation\Metrics\Metric|null $metric
      * @param \Rubix\ML\CrossValidation\Validator|null $validator
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         string $base,
@@ -262,7 +262,7 @@ class GridSearch implements Estimator, Learner, Parallel, Verbose, Wrapper, Pers
      * assign the best one as the base estimator of this instance.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -357,7 +357,7 @@ class GridSearch implements Estimator, Learner, Parallel, Verbose, Wrapper, Pers
      * Make a prediction on a given sample dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return mixed[]
      */
     public function predict(Dataset $dataset) : array

--- a/src/Kernels/Distance/Minkowski.php
+++ b/src/Kernels/Distance/Minkowski.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\Kernels\Distance;
 
 use Rubix\ML\DataType;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 /**
@@ -37,7 +37,7 @@ class Minkowski implements Distance, Stringable
 
     /**
      * @param float $lambda
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $lambda = 3.0)
     {

--- a/src/Kernels/SVM/Linear.php
+++ b/src/Kernels/SVM/Linear.php
@@ -2,7 +2,7 @@
 
 namespace Rubix\ML\Kernels\SVM;
 
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 use svm;
 
@@ -18,7 +18,7 @@ use svm;
 class Linear implements Kernel, Stringable
 {
     /**
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function __construct()
     {

--- a/src/Kernels/SVM/Polynomial.php
+++ b/src/Kernels/SVM/Polynomial.php
@@ -2,8 +2,8 @@
 
 namespace Rubix\ML\Kernels\SVM;
 
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 use svm;
 
@@ -43,8 +43,8 @@ class Polynomial implements Kernel, Stringable
      * @param int $degree
      * @param float $gamma
      * @param float $coef0
-     * @throws \InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function __construct(int $degree = 3, ?float $gamma = null, float $coef0 = 0.0)
     {

--- a/src/Kernels/SVM/RBF.php
+++ b/src/Kernels/SVM/RBF.php
@@ -2,7 +2,7 @@
 
 namespace Rubix\ML\Kernels\SVM;
 
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 use svm;
 
@@ -26,7 +26,7 @@ class RBF implements Kernel, Stringable
 
     /**
      * @param float|null $gamma
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function __construct(?float $gamma = null)
     {

--- a/src/Kernels/SVM/Sigmoidal.php
+++ b/src/Kernels/SVM/Sigmoidal.php
@@ -2,7 +2,7 @@
 
 namespace Rubix\ML\Kernels\SVM;
 
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 use svm;
 
@@ -34,7 +34,7 @@ class Sigmoidal implements Kernel, Stringable
     /**
      * @param float $gamma
      * @param float $coef0
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function __construct(?float $gamma = null, float $coef0 = 0.0)
     {

--- a/src/NeuralNet/ActivationFunctions/ELU.php
+++ b/src/NeuralNet/ActivationFunctions/ELU.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\NeuralNet\ActivationFunctions;
 
 use Tensor\Matrix;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 /**
@@ -32,7 +32,7 @@ class ELU implements ActivationFunction, Stringable
 
     /**
      * @param float $alpha
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $alpha = 1.0)
     {

--- a/src/NeuralNet/ActivationFunctions/LeakyReLU.php
+++ b/src/NeuralNet/ActivationFunctions/LeakyReLU.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\NeuralNet\ActivationFunctions;
 
 use Tensor\Matrix;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 /**
@@ -33,7 +33,7 @@ class LeakyReLU implements ActivationFunction, Stringable
 
     /**
      * @param float $leakage
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $leakage = 0.1)
     {

--- a/src/NeuralNet/ActivationFunctions/ThresholdedReLU.php
+++ b/src/NeuralNet/ActivationFunctions/ThresholdedReLU.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\NeuralNet\ActivationFunctions;
 
 use Tensor\Matrix;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 /**
@@ -31,7 +31,7 @@ class ThresholdedReLU implements ActivationFunction, Stringable
 
     /**
      * @param float $threshold
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $threshold = 1.)
     {

--- a/src/NeuralNet/CostFunctions/HuberLoss.php
+++ b/src/NeuralNet/CostFunctions/HuberLoss.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\NeuralNet\CostFunctions;
 
 use Tensor\Matrix;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 /**
@@ -38,7 +38,7 @@ class HuberLoss implements RegressionLoss, Stringable
 
     /**
      * @param float $alpha
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $alpha = 0.9)
     {

--- a/src/NeuralNet/FeedForward.php
+++ b/src/NeuralNet/FeedForward.php
@@ -12,7 +12,7 @@ use Rubix\ML\NeuralNet\Layers\Output;
 use Rubix\ML\NeuralNet\Layers\Parametric;
 use Rubix\ML\NeuralNet\Optimizers\Adaptive;
 use Rubix\ML\NeuralNet\Optimizers\Optimizer;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Traversable;
 
 /**

--- a/src/NeuralNet/Initializers/Constant.php
+++ b/src/NeuralNet/Initializers/Constant.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\NeuralNet\Initializers;
 
 use Tensor\Matrix;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 /**
@@ -26,7 +26,7 @@ class Constant implements Initializer, Stringable
 
     /**
      * @param float $value
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $value = 0.0)
     {

--- a/src/NeuralNet/Initializers/Normal.php
+++ b/src/NeuralNet/Initializers/Normal.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\NeuralNet\Initializers;
 
 use Tensor\Matrix;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 /**
@@ -27,7 +27,7 @@ class Normal implements Initializer, Stringable
 
     /**
      * @param float $stdDev
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $stdDev = 0.05)
     {

--- a/src/NeuralNet/Initializers/Uniform.php
+++ b/src/NeuralNet/Initializers/Uniform.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\NeuralNet\Initializers;
 
 use Tensor\Matrix;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 /**
@@ -27,7 +27,7 @@ class Uniform implements Initializer, Stringable
 
     /**
      * @param float $beta
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $beta = 0.5)
     {

--- a/src/NeuralNet/Layers/Activation.php
+++ b/src/NeuralNet/Layers/Activation.php
@@ -6,7 +6,7 @@ use Tensor\Matrix;
 use Rubix\ML\Deferred;
 use Rubix\ML\NeuralNet\Optimizers\Optimizer;
 use Rubix\ML\NeuralNet\ActivationFunctions\ActivationFunction;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 /**
@@ -60,7 +60,7 @@ class Activation implements Hidden, Stringable
     /**
      * Return the width of the layer.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return int
      */
     public function width() : int
@@ -119,7 +119,7 @@ class Activation implements Hidden, Stringable
      *
      * @param \Rubix\ML\Deferred $prevGradient
      * @param \Rubix\ML\NeuralNet\Optimizers\Optimizer $optimizer
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Rubix\ML\Deferred
      */
     public function back(Deferred $prevGradient, Optimizer $optimizer) : Deferred

--- a/src/NeuralNet/Layers/BatchNorm.php
+++ b/src/NeuralNet/Layers/BatchNorm.php
@@ -9,8 +9,8 @@ use Rubix\ML\NeuralNet\Optimizers\Optimizer;
 use Rubix\ML\NeuralNet\Initializers\Constant;
 use Rubix\ML\NeuralNet\Parameter;
 use Rubix\ML\NeuralNet\Initializers\Initializer;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 use Generator;
 
@@ -109,7 +109,7 @@ class BatchNorm implements Hidden, Parametric, Stringable
      * @param float $decay
      * @param \Rubix\ML\NeuralNet\Initializers\Initializer|null $betaInitializer
      * @param \Rubix\ML\NeuralNet\Initializers\Initializer|null $gammaInitializer
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         float $decay = 0.1,
@@ -129,7 +129,7 @@ class BatchNorm implements Hidden, Parametric, Stringable
     /**
      * Return the width of the layer.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return int
      */
     public function width() : int
@@ -167,7 +167,7 @@ class BatchNorm implements Hidden, Parametric, Stringable
      * Compute a forward pass through the layer.
      *
      * @param \Tensor\Matrix $input
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Tensor\Matrix
      */
     public function forward(Matrix $input) : Matrix
@@ -204,7 +204,7 @@ class BatchNorm implements Hidden, Parametric, Stringable
      * Compute an inferential pass through the layer.
      *
      * @param \Tensor\Matrix $input
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Tensor\Matrix
      */
     public function infer(Matrix $input) : Matrix
@@ -225,7 +225,7 @@ class BatchNorm implements Hidden, Parametric, Stringable
      *
      * @param \Rubix\ML\Deferred $prevGradient
      * @param \Rubix\ML\NeuralNet\Optimizers\Optimizer $optimizer
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Rubix\ML\Deferred
      */
     public function back(Deferred $prevGradient, Optimizer $optimizer) : Deferred
@@ -286,7 +286,7 @@ class BatchNorm implements Hidden, Parametric, Stringable
     /**
      * Return the parameters of the layer.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Generator<\Rubix\ML\NeuralNet\Parameter>
      */
     public function parameters() : Generator

--- a/src/NeuralNet/Layers/Binary.php
+++ b/src/NeuralNet/Layers/Binary.php
@@ -8,8 +8,8 @@ use Rubix\ML\NeuralNet\Optimizers\Optimizer;
 use Rubix\ML\NeuralNet\CostFunctions\CrossEntropy;
 use Rubix\ML\NeuralNet\ActivationFunctions\Sigmoid;
 use Rubix\ML\NeuralNet\CostFunctions\ClassificationLoss;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 use function count;
 
@@ -65,7 +65,7 @@ class Binary implements Output
     /**
      * @param string[] $classes
      * @param \Rubix\ML\NeuralNet\CostFunctions\ClassificationLoss|null $costFn
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(array $classes, ?ClassificationLoss $costFn = null)
     {
@@ -96,7 +96,7 @@ class Binary implements Output
      * the fan out for this layer.
      *
      * @param int $fanIn
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return int
      */
     public function initialize(int $fanIn) : int
@@ -140,7 +140,7 @@ class Binary implements Output
      *
      * @param string[] $labels
      * @param \Rubix\ML\NeuralNet\Optimizers\Optimizer $optimizer
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return (\Rubix\ML\Deferred|float)[]
      */
     public function back(array $labels, Optimizer $optimizer) : array

--- a/src/NeuralNet/Layers/Continuous.php
+++ b/src/NeuralNet/Layers/Continuous.php
@@ -7,8 +7,8 @@ use Rubix\ML\Deferred;
 use Rubix\ML\NeuralNet\Optimizers\Optimizer;
 use Rubix\ML\NeuralNet\CostFunctions\LeastSquares;
 use Rubix\ML\NeuralNet\CostFunctions\RegressionLoss;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * Continuous
@@ -58,7 +58,7 @@ class Continuous implements Output
      * the fan out for this layer.
      *
      * @param int $fanIn
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return int
      */
     public function initialize(int $fanIn) : int
@@ -100,7 +100,7 @@ class Continuous implements Output
      *
      * @param (int|float)[] $labels
      * @param \Rubix\ML\NeuralNet\Optimizers\Optimizer $optimizer
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return (\Rubix\ML\Deferred|float)[]
      */
     public function back(array $labels, Optimizer $optimizer) : array

--- a/src/NeuralNet/Layers/Dense.php
+++ b/src/NeuralNet/Layers/Dense.php
@@ -10,8 +10,8 @@ use Rubix\ML\NeuralNet\Initializers\He;
 use Rubix\ML\NeuralNet\Optimizers\Optimizer;
 use Rubix\ML\NeuralNet\Initializers\Constant;
 use Rubix\ML\NeuralNet\Initializers\Initializer;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 use Generator;
 
@@ -91,7 +91,7 @@ class Dense implements Hidden, Parametric, Stringable
      * @param bool $bias
      * @param \Rubix\ML\NeuralNet\Initializers\Initializer|null $weightInitializer
      * @param \Rubix\ML\NeuralNet\Initializers\Initializer|null $biasInitializer
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         int $neurons,
@@ -130,7 +130,7 @@ class Dense implements Hidden, Parametric, Stringable
     /**
      * Return the weight matrix.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Tensor\Matrix
      */
     public function weights() : Matrix
@@ -170,7 +170,7 @@ class Dense implements Hidden, Parametric, Stringable
      * Compute a forward pass through the layer.
      *
      * @param \Tensor\Matrix $input
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Tensor\Matrix
      */
     public function forward(Matrix $input) : Matrix
@@ -194,7 +194,7 @@ class Dense implements Hidden, Parametric, Stringable
      * Compute an inference pass through the layer.
      *
      * @param \Tensor\Matrix $input
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Tensor\Matrix
      */
     public function infer(Matrix $input) : Matrix
@@ -217,7 +217,7 @@ class Dense implements Hidden, Parametric, Stringable
      *
      * @param \Rubix\ML\Deferred $prevGradient
      * @param \Rubix\ML\NeuralNet\Optimizers\Optimizer $optimizer
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Rubix\ML\Deferred
      */
     public function back(Deferred $prevGradient, Optimizer $optimizer) : Deferred
@@ -269,7 +269,7 @@ class Dense implements Hidden, Parametric, Stringable
     /**
      * Return the parameters of the layer.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Generator<\Rubix\ML\NeuralNet\Parameter>
      */
     public function parameters() : Generator

--- a/src/NeuralNet/Layers/Dropout.php
+++ b/src/NeuralNet/Layers/Dropout.php
@@ -5,8 +5,8 @@ namespace Rubix\ML\NeuralNet\Layers;
 use Tensor\Matrix;
 use Rubix\ML\Deferred;
 use Rubix\ML\NeuralNet\Optimizers\Optimizer;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 /**
@@ -57,7 +57,7 @@ class Dropout implements Hidden, Stringable
 
     /**
      * @param float $ratio
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $ratio = 0.5)
     {
@@ -73,7 +73,7 @@ class Dropout implements Hidden, Stringable
     /**
      * Return the width of the layer.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return int
      */
     public function width() : int
@@ -132,7 +132,7 @@ class Dropout implements Hidden, Stringable
      *
      * @param \Rubix\ML\Deferred $prevGradient
      * @param \Rubix\ML\NeuralNet\Optimizers\Optimizer $optimizer
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Rubix\ML\Deferred
      */
     public function back(Deferred $prevGradient, Optimizer $optimizer) : Deferred

--- a/src/NeuralNet/Layers/Multiclass.php
+++ b/src/NeuralNet/Layers/Multiclass.php
@@ -8,8 +8,8 @@ use Rubix\ML\NeuralNet\Optimizers\Optimizer;
 use Rubix\ML\NeuralNet\CostFunctions\CrossEntropy;
 use Rubix\ML\NeuralNet\ActivationFunctions\Softmax;
 use Rubix\ML\NeuralNet\CostFunctions\ClassificationLoss;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 use function count;
 
@@ -65,7 +65,7 @@ class Multiclass implements Output
     /**
      * @param string[] $classes
      * @param \Rubix\ML\NeuralNet\CostFunctions\ClassificationLoss|null $costFn
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(array $classes, ?ClassificationLoss $costFn = null)
     {
@@ -97,7 +97,7 @@ class Multiclass implements Output
      * the fan out for this layer.
      *
      * @param int $fanIn
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return int
      */
     public function initialize(int $fanIn) : int
@@ -132,7 +132,7 @@ class Multiclass implements Output
      * Compute an inferential pass through the layer.
      *
      * @param \Tensor\Matrix $input
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Tensor\Matrix
      */
     public function infer(Matrix $input) : Matrix
@@ -145,7 +145,7 @@ class Multiclass implements Output
      *
      * @param string[] $labels
      * @param \Rubix\ML\NeuralNet\Optimizers\Optimizer $optimizer
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return (\Rubix\ML\Deferred|float)[]
      */
     public function back(array $labels, Optimizer $optimizer) : array

--- a/src/NeuralNet/Layers/Noise.php
+++ b/src/NeuralNet/Layers/Noise.php
@@ -5,8 +5,8 @@ namespace Rubix\ML\NeuralNet\Layers;
 use Tensor\Matrix;
 use Rubix\ML\Deferred;
 use Rubix\ML\NeuralNet\Optimizers\Optimizer;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 /**
@@ -42,7 +42,7 @@ class Noise implements Hidden, Stringable
 
     /**
      * @param float $stdDev
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $stdDev)
     {
@@ -57,7 +57,7 @@ class Noise implements Hidden, Stringable
     /**
      * Return the width of the layer.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return int
      */
     public function width() : int

--- a/src/NeuralNet/Layers/Output.php
+++ b/src/NeuralNet/Layers/Output.php
@@ -11,7 +11,7 @@ interface Output extends Layer
      *
      * @param (string|int|float)[] $labels
      * @param \Rubix\ML\NeuralNet\Optimizers\Optimizer $optimizer
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return mixed[]
      */
     public function back(array $labels, Optimizer $optimizer) : array;

--- a/src/NeuralNet/Layers/PReLU.php
+++ b/src/NeuralNet/Layers/PReLU.php
@@ -8,7 +8,7 @@ use Rubix\ML\NeuralNet\Optimizers\Optimizer;
 use Rubix\ML\NeuralNet\Initializers\Constant;
 use Rubix\ML\NeuralNet\Parameter;
 use Rubix\ML\NeuralNet\Initializers\Initializer;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 use Generator;
 
@@ -67,7 +67,7 @@ class PReLU implements Hidden, Parametric, Stringable
     /**
      * Return the width of the layer.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return int
      */
     public function width() : int
@@ -128,7 +128,7 @@ class PReLU implements Hidden, Parametric, Stringable
      *
      * @param \Rubix\ML\Deferred $prevGradient
      * @param \Rubix\ML\NeuralNet\Optimizers\Optimizer $optimizer
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Rubix\ML\Deferred
      */
     public function back(Deferred $prevGradient, Optimizer $optimizer) : Deferred
@@ -173,7 +173,7 @@ class PReLU implements Hidden, Parametric, Stringable
      * Compute the leaky ReLU activation function and return a matrix.
      *
      * @param \Tensor\Matrix $z
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Tensor\Matrix
      */
     public function compute(Matrix $z) : Matrix
@@ -207,7 +207,7 @@ class PReLU implements Hidden, Parametric, Stringable
      * Calculate the derivative of the activation function at a given output.
      *
      * @param \Tensor\Matrix $z
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Tensor\Matrix
      */
     public function differentiate(Matrix $z) : Matrix
@@ -238,7 +238,7 @@ class PReLU implements Hidden, Parametric, Stringable
     /**
      * Return the parameters of the layer.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Generator<\Rubix\ML\NeuralNet\Parameter>
      */
     public function parameters() : Generator

--- a/src/NeuralNet/Layers/Placeholder1D.php
+++ b/src/NeuralNet/Layers/Placeholder1D.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\NeuralNet\Layers;
 
 use Tensor\Matrix;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 /**
  * Placeholder 1D
@@ -26,7 +26,7 @@ class Placeholder1D implements Input
 
     /**
      * @param int $inputs
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $inputs)
     {
@@ -62,7 +62,7 @@ class Placeholder1D implements Input
      * Compute a forward pass through the layer.
      *
      * @param \Tensor\Matrix $input
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return \Tensor\Matrix
      */
     public function forward(Matrix $input) : Matrix

--- a/src/NeuralNet/Optimizers/AdaGrad.php
+++ b/src/NeuralNet/Optimizers/AdaGrad.php
@@ -4,7 +4,7 @@ namespace Rubix\ML\NeuralNet\Optimizers;
 
 use Tensor\Tensor;
 use Rubix\ML\NeuralNet\Parameter;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 use function get_class;
@@ -46,7 +46,7 @@ class AdaGrad implements Optimizer, Adaptive, Stringable
 
     /**
      * @param float $rate
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $rate = 0.01)
     {

--- a/src/NeuralNet/Optimizers/Adam.php
+++ b/src/NeuralNet/Optimizers/Adam.php
@@ -4,7 +4,7 @@ namespace Rubix\ML\NeuralNet\Optimizers;
 
 use Tensor\Tensor;
 use Rubix\ML\NeuralNet\Parameter;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 use function get_class;
@@ -92,7 +92,7 @@ class Adam implements Optimizer, Adaptive, Stringable
      * @param float $rate
      * @param float $momentumDecay
      * @param float $normDecay
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $rate = 0.001, float $momentumDecay = 0.1, float $normDecay = 0.001)
     {

--- a/src/NeuralNet/Optimizers/Cyclical.php
+++ b/src/NeuralNet/Optimizers/Cyclical.php
@@ -4,7 +4,7 @@ namespace Rubix\ML\NeuralNet\Optimizers;
 
 use Tensor\Tensor;
 use Rubix\ML\NeuralNet\Parameter;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 /**
@@ -72,7 +72,7 @@ class Cyclical implements Optimizer, Stringable
      * @param float $upper
      * @param int $steps
      * @param float $decay
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         float $lower = 0.001,

--- a/src/NeuralNet/Optimizers/Momentum.php
+++ b/src/NeuralNet/Optimizers/Momentum.php
@@ -4,7 +4,7 @@ namespace Rubix\ML\NeuralNet\Optimizers;
 
 use Tensor\Tensor;
 use Rubix\ML\NeuralNet\Parameter;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 use function get_class;
@@ -52,7 +52,7 @@ class Momentum implements Optimizer, Adaptive, Stringable
     /**
      * @param float $rate
      * @param float $decay
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $rate = 0.001, float $decay = 0.1)
     {

--- a/src/NeuralNet/Optimizers/RMSProp.php
+++ b/src/NeuralNet/Optimizers/RMSProp.php
@@ -4,7 +4,7 @@ namespace Rubix\ML\NeuralNet\Optimizers;
 
 use Tensor\Tensor;
 use Rubix\ML\NeuralNet\Parameter;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 use function get_class;
@@ -60,7 +60,7 @@ class RMSProp implements Optimizer, Adaptive, Stringable
     /**
      * @param float $rate
      * @param float $decay
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $rate = 0.001, float $decay = 0.1)
     {

--- a/src/NeuralNet/Optimizers/StepDecay.php
+++ b/src/NeuralNet/Optimizers/StepDecay.php
@@ -4,7 +4,7 @@ namespace Rubix\ML\NeuralNet\Optimizers;
 
 use Tensor\Tensor;
 use Rubix\ML\NeuralNet\Parameter;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 /**
@@ -53,7 +53,7 @@ class StepDecay implements Optimizer, Stringable
      * @param float $rate
      * @param int $steps
      * @param float $decay
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $rate = 0.01, int $steps = 100, float $decay = 1e-3)
     {

--- a/src/NeuralNet/Optimizers/Stochastic.php
+++ b/src/NeuralNet/Optimizers/Stochastic.php
@@ -4,7 +4,7 @@ namespace Rubix\ML\NeuralNet\Optimizers;
 
 use Tensor\Tensor;
 use Rubix\ML\NeuralNet\Parameter;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 /**
@@ -27,7 +27,7 @@ class Stochastic implements Optimizer, Stringable
 
     /**
      * @param float $rate
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $rate = 0.01)
     {

--- a/src/NeuralNet/Snapshot.php
+++ b/src/NeuralNet/Snapshot.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\NeuralNet;
 
 use Rubix\ML\NeuralNet\Layers\Parametric;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 /**
  * Snapshot
@@ -56,7 +56,7 @@ class Snapshot
     /**
      * @param \Rubix\ML\NeuralNet\Layers\Parametric[] $layers
      * @param array[] $parameters
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(array $layers, array $parameters)
     {

--- a/src/Other/Helpers/CPU.php
+++ b/src/Other/Helpers/CPU.php
@@ -2,7 +2,7 @@
 
 namespace Rubix\ML\Other\Helpers;
 
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 use function count;
 
@@ -32,7 +32,7 @@ class CPU
     /**
      * Return the number of cpu cores or 0 if unable to detect.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return int
      */
     public static function cores() : int

--- a/src/Other/Helpers/JSON.php
+++ b/src/Other/Helpers/JSON.php
@@ -2,7 +2,7 @@
 
 namespace Rubix\ML\Other\Helpers;
 
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 use const JSON_ERROR_NONE;
 use const JSON_ERROR_SYNTAX;
@@ -45,7 +45,7 @@ class JSON
      * @param string $json
      * @param int $options
      * @param int $depth
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return array<mixed>
      */
     public static function decode(string $json, int $options = self::DEFAULT_OPTIONS, int $depth = self::DEFAULT_DEPTH) : array

--- a/src/Other/Helpers/Params.php
+++ b/src/Other/Helpers/Params.php
@@ -2,7 +2,7 @@
 
 namespace Rubix\ML\Other\Helpers;
 
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 use function count;
@@ -30,7 +30,7 @@ class Params
      * @param int $min
      * @param int $max
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return int[]
      */
     public static function ints(int $min, int $max, int $n = 10) : array
@@ -69,7 +69,7 @@ class Params
      * @param float $min
      * @param float $max
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float[]
      */
     public static function floats(float $min, float $max, int $n = 10) : array
@@ -102,7 +102,7 @@ class Params
      * @param float $min
      * @param float $max
      * @param int $n
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float[]
      */
     public static function grid(float $min, float $max, int $n = 10) : array

--- a/src/Other/Helpers/Stats.php
+++ b/src/Other/Helpers/Stats.php
@@ -2,7 +2,7 @@
 
 namespace Rubix\ML\Other\Helpers;
 
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 use function array_slice;
 use function count;
@@ -85,7 +85,7 @@ class Stats
      *
      * @param mixed[] $values
      * @param float|null $mean
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public static function variance(array $values, ?float $mean = null) : float
@@ -109,7 +109,7 @@ class Stats
      * Calculate the median of a set of values.
      *
      * @param mixed[] $values
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public static function median(array $values) : float
@@ -138,7 +138,7 @@ class Stats
      *
      * @param mixed[] $values
      * @param float $q
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public static function quantile(array $values, float $q) : float
@@ -151,7 +151,7 @@ class Stats
      *
      * @param mixed[] $values
      * @param float[] $qs
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return (int|float)[]
      */
     public static function quantiles(array $values, array $qs) : array
@@ -191,7 +191,7 @@ class Stats
      * Compute the interquartile range of a set of values.
      *
      * @param mixed[] $values
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public static function iqr(array $values) : float
@@ -223,7 +223,7 @@ class Stats
      *
      * @param mixed[] $values
      * @param float|null $median
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public static function mad(array $values, ?float $median = null) : float
@@ -250,7 +250,7 @@ class Stats
      *
      * @param mixed[] $values
      * @param float|null $mean
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public static function skewness(array $values, ?float $mean = null) : float
@@ -272,7 +272,7 @@ class Stats
      *
      * @param mixed[] $values
      * @param float|null $mean
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public static function kurtosis(array $values, ?float $mean = null) : float
@@ -295,7 +295,7 @@ class Stats
      * @param mixed[] $values
      * @param int $moment
      * @param float|null $mean
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public static function centralMoment(array $values, int $moment, ?float $mean = null) : float
@@ -324,7 +324,7 @@ class Stats
      * of a set of values.
      *
      * @param mixed[] $values
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return float
      */
     public static function range(array $values) : float

--- a/src/Other/Helpers/Verifier.php
+++ b/src/Other/Helpers/Verifier.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\Other\Helpers;
 
 use Rubix\ML\Specifications\Specification;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 class Verifier
 {

--- a/src/Other/Strategies/KMostFrequent.php
+++ b/src/Other/Strategies/KMostFrequent.php
@@ -2,8 +2,8 @@
 
 namespace Rubix\ML\Other\Strategies;
 
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function array_slice;
@@ -38,7 +38,7 @@ class KMostFrequent implements Categorical, Stringable
 
     /**
      * @param int $k
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $k = 1)
     {
@@ -54,7 +54,7 @@ class KMostFrequent implements Categorical, Stringable
      * Fit the guessing strategy to a set of values.
      *
      * @param (string|int|float)[] $values
-     * @throws \InvalidArgumentException;
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException;
      */
     public function fit(array $values) : void
     {
@@ -75,7 +75,7 @@ class KMostFrequent implements Categorical, Stringable
     /**
      * Make a guess.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return string
      */
     public function guess() : string

--- a/src/Other/Strategies/Mean.php
+++ b/src/Other/Strategies/Mean.php
@@ -3,8 +3,8 @@
 namespace Rubix\ML\Other\Strategies;
 
 use Rubix\ML\Other\Helpers\Stats;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 /**
@@ -29,7 +29,7 @@ class Mean implements Continuous, Stringable
      * Fit the guessing strategy to a set of values.
      *
      * @param (string|int|float)[] $values
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function fit(array $values) : void
     {
@@ -44,7 +44,7 @@ class Mean implements Continuous, Stringable
     /**
      * Make a continuous guess.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return float
      */
     public function guess() : float

--- a/src/Other/Strategies/Percentile.php
+++ b/src/Other/Strategies/Percentile.php
@@ -3,8 +3,8 @@
 namespace Rubix\ML\Other\Strategies;
 
 use Rubix\ML\Other\Helpers\Stats;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 /**
@@ -34,7 +34,7 @@ class Percentile implements Continuous, Stringable
 
     /**
      * @param float $p
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $p = 50.0)
     {
@@ -50,7 +50,7 @@ class Percentile implements Continuous, Stringable
      * Fit the guessing strategy to a set of values.
      *
      * @param (string|int|float)[] $values
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function fit(array $values) : void
     {
@@ -65,7 +65,7 @@ class Percentile implements Continuous, Stringable
     /**
      * Make a guess.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return float
      */
     public function guess() : float

--- a/src/Other/Strategies/Prior.php
+++ b/src/Other/Strategies/Prior.php
@@ -2,8 +2,8 @@
 
 namespace Rubix\ML\Other\Strategies;
 
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function count;
@@ -37,7 +37,7 @@ class Prior implements Categorical, Stringable
      * Fit the guessing strategy to a set of values.
      *
      * @param string[] $values
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function fit(array $values) : void
     {
@@ -53,7 +53,7 @@ class Prior implements Categorical, Stringable
     /**
      * Make a categorical guess.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return string
      */
     public function guess() : string

--- a/src/Other/Strategies/WildGuess.php
+++ b/src/Other/Strategies/WildGuess.php
@@ -2,8 +2,8 @@
 
 namespace Rubix\ML\Other\Strategies;
 
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use const Rubix\ML\PHI;
@@ -38,7 +38,7 @@ class WildGuess implements Continuous, Stringable
      * Fit the guessing strategy to a set of values.
      *
      * @param (int|float)[] $values
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function fit(array $values) : void
     {
@@ -54,7 +54,7 @@ class WildGuess implements Continuous, Stringable
     /**
      * Make a continuous guess.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return float
      */
     public function guess() : float

--- a/src/Other/Tokenizers/NGram.php
+++ b/src/Other/Tokenizers/NGram.php
@@ -2,7 +2,7 @@
 
 namespace Rubix\ML\Other\Tokenizers;
 
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 use function count;
@@ -59,7 +59,7 @@ class NGram implements Tokenizer, Stringable
      * @param int $min
      * @param int $max
      * @param \Rubix\ML\Other\Tokenizers\Word|null $wordTokenizer
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $min = 2, int $max = 2, ?Word $wordTokenizer = null)
     {

--- a/src/Other/Tokenizers/SkipGram.php
+++ b/src/Other/Tokenizers/SkipGram.php
@@ -2,7 +2,7 @@
 
 namespace Rubix\ML\Other\Tokenizers;
 
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 use function count;
@@ -62,7 +62,7 @@ class SkipGram implements Tokenizer, Stringable
      * @param int $n
      * @param int $skip
      * @param \Rubix\ML\Other\Tokenizers\Word|null $wordTokenizer
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $n = 2, int $skip = 2, ?Word $wordTokenizer = null)
     {

--- a/src/Other/Tokenizers/Whitespace.php
+++ b/src/Other/Tokenizers/Whitespace.php
@@ -2,7 +2,7 @@
 
 namespace Rubix\ML\Other\Tokenizers;
 
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 /**
@@ -25,7 +25,7 @@ class Whitespace implements Tokenizer, Stringable
 
     /**
      * @param string $delimiter
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(string $delimiter = ' ')
     {

--- a/src/PersistentModel.php
+++ b/src/PersistentModel.php
@@ -8,8 +8,8 @@ use Rubix\ML\Other\Helpers\Params;
 use Rubix\ML\Other\Traits\ScoresSingle;
 use Rubix\ML\Other\Traits\ProbaSingle;
 use Rubix\ML\Other\Traits\PredictsSingle;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 /**
@@ -61,7 +61,7 @@ class PersistentModel implements Estimator, Learner, Wrapper, Probabilistic, Sco
     /**
      * @param \Rubix\ML\Learner $base
      * @param \Rubix\ML\Persisters\Persister $persister
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(Learner $base, Persister $persister)
     {
@@ -162,7 +162,7 @@ class PersistentModel implements Estimator, Learner, Wrapper, Probabilistic, Sco
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return array[]
      */
     public function proba(Dataset $dataset) : array
@@ -179,7 +179,7 @@ class PersistentModel implements Estimator, Learner, Wrapper, Probabilistic, Sco
      * Return the anomaly scores assigned to the samples in a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return float[]
      */
     public function score(Dataset $dataset) : array

--- a/src/Persisters/Filesystem.php
+++ b/src/Persisters/Filesystem.php
@@ -7,7 +7,7 @@ use Rubix\ML\Persistable;
 use Rubix\ML\Other\Helpers\Params;
 use Rubix\ML\Persisters\Serializers\Native;
 use Rubix\ML\Persisters\Serializers\Serializer;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function is_file;
@@ -69,7 +69,7 @@ class Filesystem implements Persister, Stringable
      * Save the persistable object.
      *
      * @param \Rubix\ML\Persistable $persistable
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function save(Persistable $persistable) : void
     {
@@ -113,7 +113,7 @@ class Filesystem implements Persister, Stringable
     /**
      * Load the last saved persistable instance.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Rubix\ML\Persistable
      */
     public function load() : Persistable

--- a/src/Persisters/RedisDB.php
+++ b/src/Persisters/RedisDB.php
@@ -6,8 +6,8 @@ use Rubix\ML\Encoding;
 use Rubix\ML\Persistable;
 use Rubix\ML\Persisters\Serializers\Native;
 use Rubix\ML\Persisters\Serializers\Serializer;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 use Redis;
 
@@ -55,8 +55,8 @@ class RedisDB implements Persister, Stringable
      * @param string|null $password
      * @param \Rubix\ML\Persisters\Serializers\Serializer|null $serializer
      * @param float $timeout
-     * @throws \InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function __construct(
         string $key,
@@ -107,7 +107,7 @@ class RedisDB implements Persister, Stringable
      * Save the persistable object.
      *
      * @param \Rubix\ML\Persistable $persistable
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function save(Persistable $persistable) : void
     {
@@ -124,7 +124,7 @@ class RedisDB implements Persister, Stringable
     /**
      * Load the last saved persistable instance.
      *
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Rubix\ML\Persistable
      */
     public function load() : Persistable

--- a/src/Persisters/Serializers/Igbinary.php
+++ b/src/Persisters/Serializers/Igbinary.php
@@ -5,7 +5,7 @@ namespace Rubix\ML\Persisters\Serializers;
 use Rubix\ML\Encoding;
 use Rubix\ML\Persistable;
 use __PHP_Incomplete_Class;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function is_null;
@@ -24,7 +24,7 @@ use function is_object;
 class Igbinary implements Serializer, Stringable
 {
     /**
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function __construct()
     {

--- a/src/Persisters/Serializers/Native.php
+++ b/src/Persisters/Serializers/Native.php
@@ -5,7 +5,7 @@ namespace Rubix\ML\Persisters\Serializers;
 use Rubix\ML\Encoding;
 use Rubix\ML\Persistable;
 use __PHP_Incomplete_Class;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function is_object;
@@ -36,7 +36,7 @@ class Native implements Serializer, Stringable
      * Unserialize a persistable object and return it.
      *
      * @param \Rubix\ML\Encoding $encoding
-     * @throws RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Rubix\ML\Persistable
      */
     public function unserialize(Encoding $encoding) : Persistable

--- a/src/Persisters/Serializers/Serializer.php
+++ b/src/Persisters/Serializers/Serializer.php
@@ -19,7 +19,7 @@ interface Serializer
      * Unserialize a persistable object and return it.
      *
      * @param \Rubix\ML\Encoding $encoding
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return \Rubix\ML\Persistable
      */
     public function unserialize(Encoding $encoding) : Persistable;

--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -12,8 +12,8 @@ use Rubix\ML\Other\Traits\ProbaSingle;
 use Rubix\ML\Other\Traits\LoggerAware;
 use Rubix\ML\Other\Traits\PredictsSingle;
 use Psr\Log\LoggerInterface;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 /**
@@ -79,7 +79,7 @@ class Pipeline implements Online, Wrapper, Probabilistic, Scoring, Ranking, Verb
      * @param \Rubix\ML\Transformers\Transformer[] $transformers
      * @param \Rubix\ML\Estimator $base
      * @param bool $elastic
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(array $transformers, Estimator $base, bool $elastic = true)
     {
@@ -243,7 +243,7 @@ class Pipeline implements Online, Wrapper, Probabilistic, Scoring, Ranking, Verb
      * Estimate the joint probabilities for each possible outcome.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return array[]
      */
     public function proba(Dataset $dataset) : array
@@ -262,7 +262,7 @@ class Pipeline implements Online, Wrapper, Probabilistic, Scoring, Ranking, Verb
      * Return the anomaly scores assigned to the samples in a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return float[]
      */
     public function score(Dataset $dataset) : array

--- a/src/Regressors/Adaline.php
+++ b/src/Regressors/Adaline.php
@@ -29,8 +29,8 @@ use Rubix\ML\NeuralNet\CostFunctions\RegressionLoss;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function is_nan;
@@ -128,7 +128,7 @@ class Adaline implements Estimator, Learner, Online, RanksFeatures, Verbose, Per
      * @param float $minChange
      * @param int $window
      * @param \Rubix\ML\NeuralNet\CostFunctions\RegressionLoss|null $costFn
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         int $batchSize = 128,
@@ -247,7 +247,7 @@ class Adaline implements Estimator, Learner, Online, RanksFeatures, Verbose, Per
      * Train the estimator with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -272,7 +272,7 @@ class Adaline implements Estimator, Learner, Online, RanksFeatures, Verbose, Per
      * Perform a partial train on the learner.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function partial(Dataset $dataset) : void
     {
@@ -360,7 +360,7 @@ class Adaline implements Estimator, Learner, Online, RanksFeatures, Verbose, Per
      * Make predictions from a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<int|float>
      */
     public function predict(Dataset $dataset) : array
@@ -377,7 +377,7 @@ class Adaline implements Estimator, Learner, Online, RanksFeatures, Verbose, Per
     /**
      * Return the normalized importance scores of each feature column of the training set.
      *
-     * @throws RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return float[]
      */
     public function featureImportances() : array

--- a/src/Regressors/DummyRegressor.php
+++ b/src/Regressors/DummyRegressor.php
@@ -17,8 +17,8 @@ use Rubix\ML\Other\Strategies\Continuous;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function count;
@@ -106,7 +106,7 @@ class DummyRegressor implements Estimator, Learner, Persistable, Stringable
      * Fit the training set to the given guessing strategy.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -129,7 +129,7 @@ class DummyRegressor implements Estimator, Learner, Persistable, Stringable
      * Make a prediction of a given sample dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<int|float>
      */
     public function predict(Dataset $dataset) : array

--- a/src/Regressors/ExtraTreeRegressor.php
+++ b/src/Regressors/ExtraTreeRegressor.php
@@ -21,8 +21,8 @@ use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 /**
@@ -49,7 +49,7 @@ class ExtraTreeRegressor extends ExtraTree implements Estimator, Learner, RanksF
      * @param int $maxLeafSize
      * @param int|null $maxFeatures
      * @param float $minPurityIncrease
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         int $maxHeight = PHP_INT_MAX,
@@ -113,7 +113,7 @@ class ExtraTreeRegressor extends ExtraTree implements Estimator, Learner, RanksF
      * training set.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -135,7 +135,7 @@ class ExtraTreeRegressor extends ExtraTree implements Estimator, Learner, RanksF
      * Make a prediction based on the value of a terminal node in the tree.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<int|float>
      */
     public function predict(Dataset $dataset) : array

--- a/src/Regressors/GradientBoost.php
+++ b/src/Regressors/GradientBoost.php
@@ -23,8 +23,8 @@ use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\EstimatorIsCompatibleWithMetric;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function count;
@@ -183,7 +183,7 @@ class GradientBoost implements Estimator, Learner, RanksFeatures, Verbose, Persi
      * @param float $holdOut
      * @param \Rubix\ML\CrossValidation\Metrics\Metric|null $metric
      * @param \Rubix\ML\Learner|null $base
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         ?Learner $booster = null,
@@ -330,8 +330,8 @@ class GradientBoost implements Estimator, Learner, RanksFeatures, Verbose, Persi
      * Train the estimator with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function train(Dataset $dataset) : void
     {
@@ -484,7 +484,7 @@ class GradientBoost implements Estimator, Learner, RanksFeatures, Verbose, Persi
      * Make a prediction from a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<int|float>
      */
     public function predict(Dataset $dataset) : array
@@ -511,7 +511,7 @@ class GradientBoost implements Estimator, Learner, RanksFeatures, Verbose, Persi
     /**
      * Return the normalized importance scores of each feature column of the training set.
      *
-     * @throws RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return float[]
      */
     public function featureImportances() : array

--- a/src/Regressors/KDNeighborsRegressor.php
+++ b/src/Regressors/KDNeighborsRegressor.php
@@ -18,8 +18,8 @@ use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 /**
@@ -72,7 +72,7 @@ class KDNeighborsRegressor implements Estimator, Learner, Persistable, Stringabl
      * @param int $k
      * @param bool $weighted
      * @param \Rubix\ML\Graph\Trees\Spatial|null $tree
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $k = 5, bool $weighted = true, ?Spatial $tree = null)
     {
@@ -142,7 +142,7 @@ class KDNeighborsRegressor implements Estimator, Learner, Persistable, Stringabl
 
     /**
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -166,7 +166,7 @@ class KDNeighborsRegressor implements Estimator, Learner, Persistable, Stringabl
      * Make a prediction based on the nearest neighbors.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<int|float>
      */
     public function predict(Dataset $dataset) : array

--- a/src/Regressors/KNNRegressor.php
+++ b/src/Regressors/KNNRegressor.php
@@ -19,8 +19,8 @@ use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function array_slice;
@@ -87,7 +87,7 @@ class KNNRegressor implements Estimator, Learner, Online, Persistable, Stringabl
      * @param int $k
      * @param bool $weighted
      * @param \Rubix\ML\Kernels\Distance\Distance|null $kernel
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $k = 5, bool $weighted = true, ?Distance $kernel = null)
     {
@@ -161,7 +161,7 @@ class KNNRegressor implements Estimator, Learner, Online, Persistable, Stringabl
      * Perform a partial train on the learner.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function partial(Dataset $dataset) : void
     {
@@ -184,7 +184,7 @@ class KNNRegressor implements Estimator, Learner, Online, Persistable, Stringabl
      * Make a prediction based on the nearest neighbors.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<int|float>
      */
     public function predict(Dataset $dataset) : array

--- a/src/Regressors/MLPRegressor.php
+++ b/src/Regressors/MLPRegressor.php
@@ -33,8 +33,8 @@ use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\EstimatorIsCompatibleWithMetric;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function is_nan;
@@ -169,7 +169,7 @@ class MLPRegressor implements Estimator, Learner, Online, Verbose, Persistable, 
      * @param float $holdOut
      * @param \Rubix\ML\NeuralNet\CostFunctions\RegressionLoss|null $costFn
      * @param \Rubix\ML\CrossValidation\Metrics\Metric|null $metric
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         array $hiddenLayers = [],
@@ -323,7 +323,7 @@ class MLPRegressor implements Estimator, Learner, Online, Verbose, Persistable, 
      * Train the estimator with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -352,8 +352,8 @@ class MLPRegressor implements Estimator, Learner, Online, Verbose, Persistable, 
      * Train the network using mini-batch gradient descent with backpropagation.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function partial(Dataset $dataset) : void
     {
@@ -474,7 +474,7 @@ class MLPRegressor implements Estimator, Learner, Online, Verbose, Persistable, 
      * activation of the output neuron.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<int|float>
      */
     public function predict(Dataset $dataset) : array

--- a/src/Regressors/RadiusNeighborsRegressor.php
+++ b/src/Regressors/RadiusNeighborsRegressor.php
@@ -18,8 +18,8 @@ use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 /**
@@ -79,7 +79,7 @@ class RadiusNeighborsRegressor implements Estimator, Learner, Persistable, Strin
      * @param float $radius
      * @param bool $weighted
      * @param \Rubix\ML\Graph\Trees\Spatial|null $tree
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $radius = 1.0, bool $weighted = true, ?Spatial $tree = null)
     {
@@ -151,7 +151,7 @@ class RadiusNeighborsRegressor implements Estimator, Learner, Persistable, Strin
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -175,7 +175,7 @@ class RadiusNeighborsRegressor implements Estimator, Learner, Persistable, Strin
      * Make a prediction based on the nearest neighbors.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<int|float>
      */
     public function predict(Dataset $dataset) : array

--- a/src/Regressors/RegressionTree.php
+++ b/src/Regressors/RegressionTree.php
@@ -21,8 +21,8 @@ use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 /**
@@ -50,7 +50,7 @@ class RegressionTree extends CART implements Estimator, Learner, RanksFeatures, 
      * @param int $maxLeafSize
      * @param int|null $maxFeatures
      * @param float $minPurityIncrease
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         int $maxHeight = PHP_INT_MAX,
@@ -113,7 +113,7 @@ class RegressionTree extends CART implements Estimator, Learner, RanksFeatures, 
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -135,7 +135,7 @@ class RegressionTree extends CART implements Estimator, Learner, RanksFeatures, 
      * Make a prediction based on the value of a terminal node in the tree.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<int|float>
      */
     public function predict(Dataset $dataset) : array

--- a/src/Regressors/Ridge.php
+++ b/src/Regressors/Ridge.php
@@ -19,8 +19,8 @@ use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\DatasetHasDimensionality;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function is_null;
@@ -63,7 +63,7 @@ class Ridge implements Estimator, Learner, RanksFeatures, Persistable, Stringabl
 
     /**
      * @param float $alpha
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $alpha = 1.0)
     {
@@ -143,7 +143,7 @@ class Ridge implements Estimator, Learner, RanksFeatures, Persistable, Stringabl
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -185,7 +185,7 @@ class Ridge implements Estimator, Learner, RanksFeatures, Persistable, Stringabl
      * Make a prediction based on the line calculated from the training data.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<int|float>
      */
     public function predict(Dataset $dataset) : array
@@ -205,7 +205,7 @@ class Ridge implements Estimator, Learner, RanksFeatures, Persistable, Stringabl
     /**
      * Return the normalized importance scores of each feature column of the training set.
      *
-     * @throws RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return float[]
      */
     public function featureImportances() : array

--- a/src/Regressors/SVR.php
+++ b/src/Regressors/SVR.php
@@ -16,8 +16,8 @@ use Rubix\ML\Other\Traits\PredictsSingle;
 use Rubix\ML\Specifications\DatasetIsNotEmpty;
 use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 use svmmodel;
 use svm;
@@ -75,8 +75,8 @@ class SVR implements Estimator, Learner, Stringable
      * @param bool $shrinking
      * @param float $tolerance
      * @param float $cacheSize
-     * @throws \RuntimeException
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         float $c = 1.0,
@@ -186,7 +186,7 @@ class SVR implements Estimator, Learner, Stringable
      * Train the learner with a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function train(Dataset $dataset) : void
     {
@@ -215,7 +215,7 @@ class SVR implements Estimator, Learner, Stringable
      * Make predictions from a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      * @return list<int|float>
      */
     public function predict(Dataset $dataset) : array
@@ -231,7 +231,7 @@ class SVR implements Estimator, Learner, Stringable
      * Save the model data to the filesystem.
      *
      * @param string $path
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function save(string $path) : void
     {

--- a/src/Report.php
+++ b/src/Report.php
@@ -2,15 +2,15 @@
 
 namespace Rubix\ML;
 
-use InvalidArgumentException;
+use ArrayAccess;
+use Countable;
+use Generator;
 use IteratorAggregate;
 use JsonSerializable;
-use Rubix\ML\Other\Helpers\JSON;
-use RuntimeException;
-use ArrayAccess;
 use Stringable;
-use Generator;
-use Countable;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
+use Rubix\ML\Other\Helpers\JSON;
 
 /**
  * Report
@@ -65,7 +65,7 @@ class Report implements ArrayAccess, JsonSerializable, IteratorAggregate, String
     /**
      * @param string|int $key
      * @param mixed[] $values
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function offsetSet($key, $values) : void
     {
@@ -87,7 +87,7 @@ class Report implements ArrayAccess, JsonSerializable, IteratorAggregate, String
      * Return an attribute from the report with the given key.
      *
      * @param string|int $key
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return mixed
      */
     public function offsetGet($key)
@@ -101,7 +101,7 @@ class Report implements ArrayAccess, JsonSerializable, IteratorAggregate, String
 
     /**
      * @param string|int $key
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function offsetUnset($key) : void
     {

--- a/src/Specifications/DatasetHasDimensionality.php
+++ b/src/Specifications/DatasetHasDimensionality.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\Specifications;
 
 use Rubix\ML\Datasets\Dataset;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 class DatasetHasDimensionality extends Specification
 {
@@ -36,7 +36,7 @@ class DatasetHasDimensionality extends Specification
     /**
      * @param \Rubix\ML\Datasets\Dataset $dataset
      * @param int $dimensions
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(Dataset $dataset, int $dimensions)
     {
@@ -52,7 +52,7 @@ class DatasetHasDimensionality extends Specification
     /**
      * Perform a check of the specification and throw an exception if invalid.
      *
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function check() : void
     {

--- a/src/Specifications/DatasetIsNotEmpty.php
+++ b/src/Specifications/DatasetIsNotEmpty.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\Specifications;
 
 use Rubix\ML\Datasets\Dataset;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 class DatasetIsNotEmpty extends Specification
 {
@@ -36,7 +36,7 @@ class DatasetIsNotEmpty extends Specification
     /**
      * Perform a check of the specification and throw an exception if invalid.
      *
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function check() : void
     {

--- a/src/Specifications/EstimatorIsCompatibleWithMetric.php
+++ b/src/Specifications/EstimatorIsCompatibleWithMetric.php
@@ -4,7 +4,7 @@ namespace Rubix\ML\Specifications;
 
 use Rubix\ML\Estimator;
 use Rubix\ML\CrossValidation\Metrics\Metric;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 use function in_array;
 
@@ -49,7 +49,7 @@ class EstimatorIsCompatibleWithMetric extends Specification
     /**
      * Perform a check of the specification and throw an exception if invalid.
      *
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function check() : void
     {

--- a/src/Specifications/LabelsAreCompatibleWithLearner.php
+++ b/src/Specifications/LabelsAreCompatibleWithLearner.php
@@ -6,7 +6,7 @@ use Rubix\ML\Learner;
 use Rubix\ML\DataType;
 use Rubix\ML\EstimatorType;
 use Rubix\ML\Datasets\Labeled;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 class LabelsAreCompatibleWithLearner extends Specification
 {
@@ -49,7 +49,7 @@ class LabelsAreCompatibleWithLearner extends Specification
     /**
      * Perform a check of the specification and throw an exception if invalid.
      *
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function check() : void
     {

--- a/src/Specifications/PredictionAndLabelCountsAreEqual.php
+++ b/src/Specifications/PredictionAndLabelCountsAreEqual.php
@@ -2,7 +2,7 @@
 
 namespace Rubix\ML\Specifications;
 
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 class PredictionAndLabelCountsAreEqual
 {
@@ -45,7 +45,7 @@ class PredictionAndLabelCountsAreEqual
     /**
      * Perform a check of the specification and throw an exception if invalid.
      *
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function check() : void
     {

--- a/src/Specifications/SamplesAreCompatibleWithDistance.php
+++ b/src/Specifications/SamplesAreCompatibleWithDistance.php
@@ -4,7 +4,7 @@ namespace Rubix\ML\Specifications;
 
 use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Kernels\Distance\Distance;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 use function count;
 
@@ -49,7 +49,7 @@ class SamplesAreCompatibleWithDistance extends Specification
     /**
      * Perform a check of the specification and throw an exception if invalid.
      *
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function check() : void
     {

--- a/src/Specifications/SamplesAreCompatibleWithEstimator.php
+++ b/src/Specifications/SamplesAreCompatibleWithEstimator.php
@@ -4,7 +4,7 @@ namespace Rubix\ML\Specifications;
 
 use Rubix\ML\Estimator;
 use Rubix\ML\Datasets\Dataset;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 use function count;
 
@@ -49,7 +49,7 @@ class SamplesAreCompatibleWithEstimator extends Specification
     /**
      * Perform a check of the specification and throw an exception if invalid.
      *
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function check() : void
     {

--- a/src/Specifications/SamplesAreCompatibleWithTransformer.php
+++ b/src/Specifications/SamplesAreCompatibleWithTransformer.php
@@ -4,7 +4,7 @@ namespace Rubix\ML\Specifications;
 
 use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Transformers\Transformer;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 use function count;
 
@@ -49,7 +49,7 @@ class SamplesAreCompatibleWithTransformer extends Specification
     /**
      * Perform a check of the specification.
      *
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function check() : void
     {

--- a/src/Transformers/GaussianRandomProjector.php
+++ b/src/Transformers/GaussianRandomProjector.php
@@ -6,8 +6,8 @@ use Tensor\Matrix;
 use Rubix\ML\DataType;
 use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 /**
@@ -46,7 +46,7 @@ class GaussianRandomProjector implements Transformer, Stateful, Stringable
      *
      * @param int $n
      * @param float $maxDistortion
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      * @return int
      */
     public static function minDimensions(int $n, float $maxDistortion = 0.5) : int
@@ -68,7 +68,7 @@ class GaussianRandomProjector implements Transformer, Stateful, Stringable
 
     /**
      * @param int $dimensions
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $dimensions)
     {
@@ -106,7 +106,7 @@ class GaussianRandomProjector implements Transformer, Stateful, Stringable
      * Fit the transformer to a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function fit(Dataset $dataset) : void
     {
@@ -119,7 +119,7 @@ class GaussianRandomProjector implements Transformer, Stateful, Stringable
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/src/Transformers/ImageResizer.php
+++ b/src/Transformers/ImageResizer.php
@@ -3,8 +3,8 @@
 namespace Rubix\ML\Transformers;
 
 use Rubix\ML\DataType;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 /**
@@ -44,7 +44,7 @@ class ImageResizer implements Transformer, Stringable
     /**
      * @param int $width
      * @param int $height
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $width = 32, int $height = 32)
     {
@@ -77,7 +77,7 @@ class ImageResizer implements Transformer, Stringable
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/src/Transformers/ImageVectorizer.php
+++ b/src/Transformers/ImageVectorizer.php
@@ -6,7 +6,7 @@ use Rubix\ML\DataType;
 use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Other\Helpers\Params;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function is_null;
@@ -42,8 +42,8 @@ class ImageVectorizer implements Transformer, Stateful, Stringable
 
     /**
      * @param bool $grayscale
-     * @throws \InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function __construct(bool $grayscale = false)
     {
@@ -79,7 +79,7 @@ class ImageVectorizer implements Transformer, Stateful, Stringable
      * Fit the transformer to a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function fit(Dataset $dataset) : void
     {
@@ -105,7 +105,7 @@ class ImageVectorizer implements Transformer, Stateful, Stringable
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/src/Transformers/IntervalDiscretizer.php
+++ b/src/Transformers/IntervalDiscretizer.php
@@ -6,8 +6,8 @@ use Tensor\Vector;
 use Rubix\ML\DataType;
 use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function chr;
@@ -56,7 +56,7 @@ class IntervalDiscretizer implements Transformer, Stateful, Stringable
 
     /**
      * @param int $bins
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $bins = 5)
     {
@@ -117,7 +117,7 @@ class IntervalDiscretizer implements Transformer, Stateful, Stringable
      * Fit the transformer to a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function fit(Dataset $dataset) : void
     {
@@ -142,7 +142,7 @@ class IntervalDiscretizer implements Transformer, Stateful, Stringable
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/src/Transformers/KNNImputer.php
+++ b/src/Transformers/KNNImputer.php
@@ -12,8 +12,8 @@ use Rubix\ML\Kernels\Distance\NaNSafe;
 use Rubix\ML\Kernels\Distance\Distance;
 use Rubix\ML\Kernels\Distance\SafeEuclidean;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function Rubix\ML\argmax;
@@ -79,7 +79,7 @@ class KNNImputer implements Transformer, Stateful, Stringable
      * @param bool $weighted
      * @param string $categoricalPlaceholder
      * @param \Rubix\ML\Graph\Trees\Spatial|null $tree
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         int $k = 5,
@@ -131,7 +131,7 @@ class KNNImputer implements Transformer, Stateful, Stringable
      * Fit the transformer to a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function fit(Dataset $dataset) : void
     {
@@ -170,7 +170,7 @@ class KNNImputer implements Transformer, Stateful, Stringable
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/src/Transformers/LinearDiscriminantAnalysis.php
+++ b/src/Transformers/LinearDiscriminantAnalysis.php
@@ -7,8 +7,8 @@ use Rubix\ML\DataType;
 use Rubix\ML\Datasets\Labeled;
 use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function array_slice;
@@ -66,7 +66,7 @@ class LinearDiscriminantAnalysis implements Transformer, Stateful, Stringable
 
     /**
      * @param int $dimensions
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $dimensions)
     {
@@ -135,7 +135,7 @@ class LinearDiscriminantAnalysis implements Transformer, Stateful, Stringable
      * Fit the transformer to a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function fit(Dataset $dataset) : void
     {
@@ -196,7 +196,7 @@ class LinearDiscriminantAnalysis implements Transformer, Stateful, Stringable
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/src/Transformers/MaxAbsoluteScaler.php
+++ b/src/Transformers/MaxAbsoluteScaler.php
@@ -5,7 +5,7 @@ namespace Rubix\ML\Transformers;
 use Rubix\ML\DataType;
 use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use const Rubix\ML\EPSILON;
@@ -107,7 +107,7 @@ class MaxAbsoluteScaler implements Transformer, Stateful, Elastic, Stringable
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/src/Transformers/MinMaxNormalizer.php
+++ b/src/Transformers/MinMaxNormalizer.php
@@ -5,8 +5,8 @@ namespace Rubix\ML\Transformers;
 use Rubix\ML\DataType;
 use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use const Rubix\ML\EPSILON;
@@ -68,7 +68,7 @@ class MinMaxNormalizer implements Transformer, Stateful, Elastic, Stringable
     /**
      * @param float $min
      * @param float $max
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(float $min = 0.0, float $max = 1.0)
     {
@@ -184,7 +184,7 @@ class MinMaxNormalizer implements Transformer, Stateful, Elastic, Stringable
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/src/Transformers/MissingDataImputer.php
+++ b/src/Transformers/MissingDataImputer.php
@@ -9,8 +9,8 @@ use Rubix\ML\Other\Strategies\Continuous;
 use Rubix\ML\Other\Strategies\Categorical;
 use Rubix\ML\Other\Strategies\KMostFrequent;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function is_null;
@@ -66,7 +66,7 @@ class MissingDataImputer implements Transformer, Stateful, Stringable
      * @param \Rubix\ML\Other\Strategies\Continuous|null $continuous
      * @param \Rubix\ML\Other\Strategies\Categorical|null $categorical
      * @param string $categoricalPlaceholder
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         ?Continuous $continuous = null,
@@ -102,7 +102,7 @@ class MissingDataImputer implements Transformer, Stateful, Stringable
      * Fit the transformer to a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function fit(Dataset $dataset) : void
     {
@@ -159,7 +159,7 @@ class MissingDataImputer implements Transformer, Stateful, Stringable
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/src/Transformers/OneHotEncoder.php
+++ b/src/Transformers/OneHotEncoder.php
@@ -5,7 +5,7 @@ namespace Rubix\ML\Transformers;
 use Rubix\ML\DataType;
 use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function count;
@@ -91,7 +91,7 @@ class OneHotEncoder implements Transformer, Stateful, Stringable
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/src/Transformers/PolynomialExpander.php
+++ b/src/Transformers/PolynomialExpander.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\Transformers;
 
 use Rubix\ML\DataType;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 /**
@@ -31,7 +31,7 @@ class PolynomialExpander implements Transformer, Stringable
 
     /**
      * @param int $degree
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $degree = 2)
     {

--- a/src/Transformers/PrincipalComponentAnalysis.php
+++ b/src/Transformers/PrincipalComponentAnalysis.php
@@ -6,8 +6,8 @@ use Tensor\Matrix;
 use Rubix\ML\DataType;
 use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function array_slice;
@@ -77,7 +77,7 @@ class PrincipalComponentAnalysis implements Transformer, Stateful, Stringable
 
     /**
      * @param int $dimensions
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $dimensions)
     {
@@ -146,7 +146,7 @@ class PrincipalComponentAnalysis implements Transformer, Stateful, Stringable
      * Fit the transformer to a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function fit(Dataset $dataset) : void
     {
@@ -185,7 +185,7 @@ class PrincipalComponentAnalysis implements Transformer, Stateful, Stringable
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/src/Transformers/RecursiveFeatureEliminator.php
+++ b/src/Transformers/RecursiveFeatureEliminator.php
@@ -10,8 +10,8 @@ use Rubix\ML\Datasets\Labeled;
 use Rubix\ML\Other\Traits\LoggerAware;
 use Rubix\ML\Regressors\RegressionTree;
 use Rubix\ML\Classifiers\ClassificationTree;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 use function count;
 use function is_null;
@@ -146,7 +146,7 @@ class RecursiveFeatureEliminator implements Transformer, Stateful, Verbose
      * Fit the transformer to the dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function fit(Dataset $dataset) : void
     {
@@ -243,7 +243,7 @@ class RecursiveFeatureEliminator implements Transformer, Stateful, Verbose
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/src/Transformers/RegexFilter.php
+++ b/src/Transformers/RegexFilter.php
@@ -3,7 +3,7 @@
 namespace Rubix\ML\Transformers;
 
 use Rubix\ML\DataType;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Stringable;
 
 use function gettype;
@@ -91,7 +91,7 @@ class RegexFilter implements Transformer, Stringable
 
     /**
      * @param string[] $patterns
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(array $patterns)
     {

--- a/src/Transformers/RobustStandardizer.php
+++ b/src/Transformers/RobustStandardizer.php
@@ -7,7 +7,7 @@ use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Other\Helpers\Stats;
 use Rubix\ML\Other\Helpers\Params;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function is_null;
@@ -125,7 +125,7 @@ class RobustStandardizer implements Transformer, Stateful, Stringable
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/src/Transformers/SparseRandomProjector.php
+++ b/src/Transformers/SparseRandomProjector.php
@@ -5,7 +5,7 @@ namespace Rubix\ML\Transformers;
 use Tensor\Matrix;
 use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 use function count;
 use function is_null;
@@ -44,7 +44,7 @@ class SparseRandomProjector extends GaussianRandomProjector
     /**
      * @param int $dimensions
      * @param float|null $sparsity
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $dimensions, ?float $sparsity = self::TWO_THIRDS)
     {
@@ -62,7 +62,7 @@ class SparseRandomProjector extends GaussianRandomProjector
      * Fit the transformer to a dataset.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function fit(Dataset $dataset) : void
     {

--- a/src/Transformers/StopWordFilter.php
+++ b/src/Transformers/StopWordFilter.php
@@ -2,7 +2,7 @@
 
 namespace Rubix\ML\Transformers;
 
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 use function gettype;
 
@@ -20,7 +20,7 @@ class StopWordFilter extends RegexFilter
 {
     /**
      * @param string[] $stopWords
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(array $stopWords = [])
     {

--- a/src/Transformers/TfIdfTransformer.php
+++ b/src/Transformers/TfIdfTransformer.php
@@ -5,8 +5,8 @@ namespace Rubix\ML\Transformers;
 use Rubix\ML\DataType;
 use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function is_null;
@@ -124,7 +124,7 @@ class TfIdfTransformer implements Transformer, Stateful, Elastic, Stringable
      * Update the fitting of the transformer.
      *
      * @param \Rubix\ML\Datasets\Dataset $dataset
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function update(Dataset $dataset) : void
     {
@@ -161,7 +161,7 @@ class TfIdfTransformer implements Transformer, Stateful, Elastic, Stringable
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/src/Transformers/VarianceThresholdFilter.php
+++ b/src/Transformers/VarianceThresholdFilter.php
@@ -6,8 +6,8 @@ use Rubix\ML\DataType;
 use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Other\Helpers\Stats;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function is_null;
@@ -39,7 +39,7 @@ class VarianceThresholdFilter implements Transformer, Stateful, Stringable
 
     /**
      * @param int $minFeatures
-     * @throws \InvalidArgumentException
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(int $minFeatures)
     {
@@ -109,7 +109,7 @@ class VarianceThresholdFilter implements Transformer, Stateful, Stringable
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/src/Transformers/WordCountVectorizer.php
+++ b/src/Transformers/WordCountVectorizer.php
@@ -7,8 +7,8 @@ use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Other\Tokenizers\Word;
 use Rubix\ML\Other\Tokenizers\Tokenizer;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function count;
@@ -188,7 +188,7 @@ class WordCountVectorizer implements Transformer, Stateful, Stringable
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/src/Transformers/ZScaleStandardizer.php
+++ b/src/Transformers/ZScaleStandardizer.php
@@ -7,7 +7,7 @@ use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Other\Helpers\Stats;
 use Rubix\ML\Other\Helpers\Params;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Stringable;
 
 use function is_null;
@@ -192,7 +192,7 @@ class ZScaleStandardizer implements Transformer, Stateful, Elastic, Stringable
      * Transform the dataset in place.
      *
      * @param array[] $samples
-     * @throws \RuntimeException
+     * @throws \Rubix\ML\Exceptions\RuntimeException
      */
     public function transform(array &$samples) : void
     {

--- a/tests/AnomalyDetectors/GaussianMLETest.php
+++ b/tests/AnomalyDetectors/GaussianMLETest.php
@@ -16,8 +16,8 @@ use Rubix\ML\AnomalyDetectors\GaussianMLE;
 use Rubix\ML\CrossValidation\Metrics\FBeta;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group AnomalyDetectors

--- a/tests/AnomalyDetectors/IsolationForestTest.php
+++ b/tests/AnomalyDetectors/IsolationForestTest.php
@@ -15,8 +15,8 @@ use Rubix\ML\CrossValidation\Metrics\FBeta;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\AnomalyDetectors\IsolationForest;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group AnomalyDetectors

--- a/tests/AnomalyDetectors/LocalOutlierFactorTest.php
+++ b/tests/AnomalyDetectors/LocalOutlierFactorTest.php
@@ -16,8 +16,8 @@ use Rubix\ML\CrossValidation\Metrics\FBeta;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\AnomalyDetectors\LocalOutlierFactor;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group AnomalyDetectors

--- a/tests/AnomalyDetectors/LodaTest.php
+++ b/tests/AnomalyDetectors/LodaTest.php
@@ -16,8 +16,8 @@ use Rubix\ML\Datasets\Generators\Circle;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\FBeta;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group AnomalyDetectors

--- a/tests/AnomalyDetectors/OneClassSVMTest.php
+++ b/tests/AnomalyDetectors/OneClassSVMTest.php
@@ -14,8 +14,8 @@ use Rubix\ML\AnomalyDetectors\OneClassSVM;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\FBeta;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group AnomalyDetectors

--- a/tests/AnomalyDetectors/RobustZScoreTest.php
+++ b/tests/AnomalyDetectors/RobustZScoreTest.php
@@ -15,8 +15,8 @@ use Rubix\ML\AnomalyDetectors\RobustZScore;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\FBeta;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group AnomalyDetectors

--- a/tests/BootstrapAggregatorTest.php
+++ b/tests/BootstrapAggregatorTest.php
@@ -14,7 +14,7 @@ use Rubix\ML\Regressors\RegressionTree;
 use Rubix\ML\Datasets\Generators\SwissRoll;
 use Rubix\ML\CrossValidation\Metrics\RSquared;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group MetaEstimators

--- a/tests/Classifiers/AdaBoostTest.php
+++ b/tests/Classifiers/AdaBoostTest.php
@@ -17,8 +17,8 @@ use Rubix\ML\Classifiers\ClassificationTree;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\Accuracy;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Classifiers

--- a/tests/Classifiers/ClassificationTreeTest.php
+++ b/tests/Classifiers/ClassificationTreeTest.php
@@ -15,8 +15,8 @@ use Rubix\ML\Classifiers\ClassificationTree;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\Accuracy;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Classifiers

--- a/tests/Classifiers/ExtraTreeClassifierTest.php
+++ b/tests/Classifiers/ExtraTreeClassifierTest.php
@@ -15,8 +15,8 @@ use Rubix\ML\Classifiers\ExtraTreeClassifier;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\Accuracy;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Classifiers

--- a/tests/Classifiers/GaussianNBTest.php
+++ b/tests/Classifiers/GaussianNBTest.php
@@ -15,8 +15,8 @@ use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\Accuracy;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Classifiers

--- a/tests/Classifiers/KDNeighborsTest.php
+++ b/tests/Classifiers/KDNeighborsTest.php
@@ -15,8 +15,8 @@ use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\Accuracy;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Classifiers

--- a/tests/Classifiers/KNearestNeighborsTest.php
+++ b/tests/Classifiers/KNearestNeighborsTest.php
@@ -16,8 +16,8 @@ use Rubix\ML\Classifiers\KNearestNeighbors;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\Accuracy;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Classifiers

--- a/tests/Classifiers/LogisticRegressionTest.php
+++ b/tests/Classifiers/LogisticRegressionTest.php
@@ -21,8 +21,8 @@ use Rubix\ML\Transformers\ZScaleStandardizer;
 use Rubix\ML\CrossValidation\Metrics\Accuracy;
 use Rubix\ML\NeuralNet\CostFunctions\CrossEntropy;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Classifiers

--- a/tests/Classifiers/MultilayerPerceptronTest.php
+++ b/tests/Classifiers/MultilayerPerceptronTest.php
@@ -25,8 +25,8 @@ use Rubix\ML\CrossValidation\Metrics\Accuracy;
 use Rubix\ML\NeuralNet\CostFunctions\CrossEntropy;
 use Rubix\ML\NeuralNet\ActivationFunctions\LeakyReLU;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Classifiers

--- a/tests/Classifiers/NaiveBayesTest.php
+++ b/tests/Classifiers/NaiveBayesTest.php
@@ -16,8 +16,8 @@ use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\Transformers\IntervalDiscretizer;
 use Rubix\ML\CrossValidation\Metrics\Accuracy;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Classifiers

--- a/tests/Classifiers/RadiusNeighborsTest.php
+++ b/tests/Classifiers/RadiusNeighborsTest.php
@@ -15,8 +15,8 @@ use Rubix\ML\Classifiers\RadiusNeighbors;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\Accuracy;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Classifiers

--- a/tests/Classifiers/RandomForestTest.php
+++ b/tests/Classifiers/RandomForestTest.php
@@ -17,8 +17,8 @@ use Rubix\ML\Classifiers\ClassificationTree;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\Accuracy;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Classifiers

--- a/tests/Classifiers/SVCTest.php
+++ b/tests/Classifiers/SVCTest.php
@@ -14,8 +14,8 @@ use Rubix\ML\Transformers\ZScaleStandardizer;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\Accuracy;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Classifiers

--- a/tests/Classifiers/SoftmaxClassifierTest.php
+++ b/tests/Classifiers/SoftmaxClassifierTest.php
@@ -20,8 +20,8 @@ use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\Accuracy;
 use Rubix\ML\NeuralNet\CostFunctions\CrossEntropy;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Classifiers

--- a/tests/Clusterers/DBSCANTest.php
+++ b/tests/Clusterers/DBSCANTest.php
@@ -12,7 +12,7 @@ use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\VMeasure;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 /**
  * @group Clusterers

--- a/tests/Clusterers/FuzzyCMeansTest.php
+++ b/tests/Clusterers/FuzzyCMeansTest.php
@@ -18,8 +18,8 @@ use Rubix\ML\Kernels\Distance\Euclidean;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\VMeasure;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Clusterers

--- a/tests/Clusterers/GaussianMixtureTest.php
+++ b/tests/Clusterers/GaussianMixtureTest.php
@@ -17,8 +17,8 @@ use Rubix\ML\Clusterers\GaussianMixture;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\VMeasure;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Clusterers

--- a/tests/Clusterers/KMeansTest.php
+++ b/tests/Clusterers/KMeansTest.php
@@ -19,8 +19,8 @@ use Rubix\ML\Clusterers\Seeders\PlusPlus;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\VMeasure;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Clusterers

--- a/tests/Clusterers/MeanShiftTest.php
+++ b/tests/Clusterers/MeanShiftTest.php
@@ -18,8 +18,8 @@ use Rubix\ML\Clusterers\Seeders\Random;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\VMeasure;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Clusterers

--- a/tests/CommitteeMachineTest.php
+++ b/tests/CommitteeMachineTest.php
@@ -20,8 +20,8 @@ use Rubix\ML\Classifiers\ClassificationTree;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\Accuracy;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group MetaEstimators

--- a/tests/Embedders/TSNETest.php
+++ b/tests/Embedders/TSNETest.php
@@ -10,7 +10,7 @@ use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Kernels\Distance\Euclidean;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 /**
  * @group Embedders

--- a/tests/NeuralNet/ActivationFunctions/ELUTest.php
+++ b/tests/NeuralNet/ActivationFunctions/ELUTest.php
@@ -6,7 +6,7 @@ use Tensor\Matrix;
 use Rubix\ML\NeuralNet\ActivationFunctions\ELU;
 use Rubix\ML\NeuralNet\ActivationFunctions\ActivationFunction;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use Generator;
 
 /**

--- a/tests/Persisters/Serializers/NativeTest.php
+++ b/tests/Persisters/Serializers/NativeTest.php
@@ -8,7 +8,7 @@ use Rubix\ML\Classifiers\DummyClassifier;
 use Rubix\ML\Persisters\Serializers\Native;
 use Rubix\ML\Persisters\Serializers\Serializer;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use stdClass;
 
 use function serialize;

--- a/tests/PipelineTest.php
+++ b/tests/PipelineTest.php
@@ -21,7 +21,7 @@ use Rubix\ML\Transformers\ZScaleStandardizer;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\CrossValidation\Metrics\Accuracy;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group MetaEstimators

--- a/tests/Regressors/AdalineTest.php
+++ b/tests/Regressors/AdalineTest.php
@@ -18,8 +18,8 @@ use Rubix\ML\Datasets\Generators\Hyperplane;
 use Rubix\ML\CrossValidation\Metrics\RSquared;
 use Rubix\ML\NeuralNet\CostFunctions\HuberLoss;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Regressors

--- a/tests/Regressors/DummyRegressorTest.php
+++ b/tests/Regressors/DummyRegressorTest.php
@@ -13,7 +13,7 @@ use Rubix\ML\Regressors\DummyRegressor;
 use Rubix\ML\Datasets\Generators\Hyperplane;
 use Rubix\ML\CrossValidation\Metrics\RSquared;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 
 /**
  * @group Regressors

--- a/tests/Regressors/ExtraTreeRegressorTest.php
+++ b/tests/Regressors/ExtraTreeRegressorTest.php
@@ -13,8 +13,8 @@ use Rubix\ML\Regressors\ExtraTreeRegressor;
 use Rubix\ML\Datasets\Generators\Hyperplane;
 use Rubix\ML\CrossValidation\Metrics\RSquared;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Regressors

--- a/tests/Regressors/GradientBoostTest.php
+++ b/tests/Regressors/GradientBoostTest.php
@@ -18,8 +18,8 @@ use Rubix\ML\CrossValidation\Metrics\RMSE;
 use Rubix\ML\Datasets\Generators\SwissRoll;
 use Rubix\ML\CrossValidation\Metrics\RSquared;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Regressors

--- a/tests/Regressors/KDNeighborsRegressorTest.php
+++ b/tests/Regressors/KDNeighborsRegressorTest.php
@@ -13,8 +13,8 @@ use Rubix\ML\Datasets\Generators\HalfMoon;
 use Rubix\ML\Regressors\KDNeighborsRegressor;
 use Rubix\ML\CrossValidation\Metrics\RSquared;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Regressors

--- a/tests/Regressors/KNNRegressorTest.php
+++ b/tests/Regressors/KNNRegressorTest.php
@@ -14,8 +14,8 @@ use Rubix\ML\Kernels\Distance\Minkowski;
 use Rubix\ML\Datasets\Generators\HalfMoon;
 use Rubix\ML\CrossValidation\Metrics\RSquared;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Regressors

--- a/tests/Regressors/MLPRegressorTest.php
+++ b/tests/Regressors/MLPRegressorTest.php
@@ -22,8 +22,8 @@ use Rubix\ML\CrossValidation\Metrics\RSquared;
 use Rubix\ML\NeuralNet\CostFunctions\LeastSquares;
 use Rubix\ML\NeuralNet\ActivationFunctions\LeakyReLU;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Regressors

--- a/tests/Regressors/RadiusNeighborsRegressorTest.php
+++ b/tests/Regressors/RadiusNeighborsRegressorTest.php
@@ -13,8 +13,8 @@ use Rubix\ML\Datasets\Generators\Hyperplane;
 use Rubix\ML\CrossValidation\Metrics\RSquared;
 use Rubix\ML\Regressors\RadiusNeighborsRegressor;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Regressors

--- a/tests/Regressors/RegressionTreeTest.php
+++ b/tests/Regressors/RegressionTreeTest.php
@@ -13,8 +13,8 @@ use Rubix\ML\Regressors\RegressionTree;
 use Rubix\ML\Datasets\Generators\HalfMoon;
 use Rubix\ML\CrossValidation\Metrics\RSquared;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Regressors

--- a/tests/Regressors/RidgeTest.php
+++ b/tests/Regressors/RidgeTest.php
@@ -13,8 +13,8 @@ use Rubix\ML\Datasets\Unlabeled;
 use Rubix\ML\Datasets\Generators\Hyperplane;
 use Rubix\ML\CrossValidation\Metrics\RSquared;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Regressors

--- a/tests/Regressors/SVRTest.php
+++ b/tests/Regressors/SVRTest.php
@@ -13,8 +13,8 @@ use Rubix\ML\Datasets\Generators\Hyperplane;
 use Rubix\ML\Transformers\ZScaleStandardizer;
 use Rubix\ML\CrossValidation\Metrics\RSquared;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
-use RuntimeException;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Regressors

--- a/tests/Transformers/DenseRandomProjectorTest.php
+++ b/tests/Transformers/DenseRandomProjectorTest.php
@@ -7,7 +7,7 @@ use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Transformers\DenseRandomProjector;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Transformers

--- a/tests/Transformers/GaussianRandomProjectorTest.php
+++ b/tests/Transformers/GaussianRandomProjectorTest.php
@@ -7,7 +7,7 @@ use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Transformers\GaussianRandomProjector;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 use Generator;
 
 /**

--- a/tests/Transformers/IntervalDiscretizerTest.php
+++ b/tests/Transformers/IntervalDiscretizerTest.php
@@ -7,7 +7,7 @@ use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Transformers\IntervalDiscretizer;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Transformers

--- a/tests/Transformers/KNNImputerTest.php
+++ b/tests/Transformers/KNNImputerTest.php
@@ -8,7 +8,7 @@ use Rubix\ML\Transformers\KNNImputer;
 use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Datasets\Generators\Blob;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Transformers

--- a/tests/Transformers/LinearDiscriminantAnalysisTest.php
+++ b/tests/Transformers/LinearDiscriminantAnalysisTest.php
@@ -8,7 +8,7 @@ use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\Transformers\LinearDiscriminantAnalysis;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Transformers

--- a/tests/Transformers/MaxAbsoluteScalerTest.php
+++ b/tests/Transformers/MaxAbsoluteScalerTest.php
@@ -8,7 +8,7 @@ use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Transformers\MaxAbsoluteScaler;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Transformers

--- a/tests/Transformers/MinMaxNormalizerTest.php
+++ b/tests/Transformers/MinMaxNormalizerTest.php
@@ -8,7 +8,7 @@ use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Transformers\MinMaxNormalizer;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Transformers

--- a/tests/Transformers/MissingDataImputerTest.php
+++ b/tests/Transformers/MissingDataImputerTest.php
@@ -9,7 +9,7 @@ use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Other\Strategies\KMostFrequent;
 use Rubix\ML\Transformers\MissingDataImputer;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Transformers

--- a/tests/Transformers/OneHotEncoderTest.php
+++ b/tests/Transformers/OneHotEncoderTest.php
@@ -7,7 +7,7 @@ use Rubix\ML\Transformers\Stateful;
 use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Transformers\OneHotEncoder;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Transformers

--- a/tests/Transformers/PrincipalComponentAnalysisTest.php
+++ b/tests/Transformers/PrincipalComponentAnalysisTest.php
@@ -7,7 +7,7 @@ use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Transformers\PrincipalComponentAnalysis;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Transformers

--- a/tests/Transformers/RandomHotDeckImputerTest.php
+++ b/tests/Transformers/RandomHotDeckImputerTest.php
@@ -8,7 +8,7 @@ use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Transformers\RandomHotDeckImputer;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Transformers

--- a/tests/Transformers/RecursiveFeatureEliminatorTest.php
+++ b/tests/Transformers/RecursiveFeatureEliminatorTest.php
@@ -8,7 +8,7 @@ use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\Transformers\RecursiveFeatureEliminator;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 class RecursiveFeatureEliminatorTest extends TestCase
 {

--- a/tests/Transformers/RobustStandardizerTest.php
+++ b/tests/Transformers/RobustStandardizerTest.php
@@ -7,7 +7,7 @@ use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Transformers\RobustStandardizer;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Transformers

--- a/tests/Transformers/SparseRandomProjectorTest.php
+++ b/tests/Transformers/SparseRandomProjectorTest.php
@@ -7,7 +7,7 @@ use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Transformers\SparseRandomProjector;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Transformers

--- a/tests/Transformers/TfIdfTransformerTest.php
+++ b/tests/Transformers/TfIdfTransformerTest.php
@@ -8,7 +8,7 @@ use Rubix\ML\Transformers\Stateful;
 use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Transformers\TfIdfTransformer;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Transformers

--- a/tests/Transformers/VarianceThresholdFilterTest.php
+++ b/tests/Transformers/VarianceThresholdFilterTest.php
@@ -7,7 +7,7 @@ use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Transformers\VarianceThresholdFilter;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Transformers

--- a/tests/Transformers/WordCountVectorizerTest.php
+++ b/tests/Transformers/WordCountVectorizerTest.php
@@ -8,7 +8,7 @@ use Rubix\ML\Other\Tokenizers\Word;
 use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Transformers\WordCountVectorizer;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Transformers

--- a/tests/Transformers/ZScaleStandardizerTest.php
+++ b/tests/Transformers/ZScaleStandardizerTest.php
@@ -8,7 +8,7 @@ use Rubix\ML\Transformers\Transformer;
 use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Transformers\ZScaleStandardizer;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 /**
  * @group Transformers


### PR DESCRIPTION
#### SUMMARY:

This PR introduces the `Rubix\ML\Exceptions` namespace.

Existing exceptions in the global namespace  are now thrown as the equivalent exception in the `Rubix\ML\Exceptions` namespace (e.g. `\InvalidArgumentException` is now `\Rubix\ML\Exceptions\InvalidArgumentException`). These exceptions all implement the `RubixMLException` interface which can now act as a generic flag to catch things thrown from within the library.

This PR introduces no BC breaks: if existing user-land code is catching `\RuntimeException`, `\InvalidArgumentException` etc then this is still valid as the new Exceptions also extend them. This paves the way for more expressive and granular error types in the future, and perhaps a larger overhaul of the exceptions hierarchy in 1.0 or beyond. 

I've purposely kept the scope of this PR targeted to the existing exceptions to avoid introducing too many new changes in a single leap.
