### PR TITLE
Optimize StopWordFilter 

### DIFF
--- a/benchmarks/Transformers/StopWordFilterBench.php
+++ b/benchmarks/Transformers/StopWordFilterBench.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Rubix\ML\Benchmarks\Transformers;
+
+use Rubix\ML\Datasets\Unlabeled;
+use Rubix\ML\Transformers\StopWordFilter;
+
+/**
+ * @Groups({"Transformers"})
+ * @BeforeMethods({"setUp"})
+ */
+class StopWordFilterBench
+{
+    protected const DATASET_SIZE = 100000;
+
+    protected const LUCENE_STOPWORDS_EN = [
+        'a', 'an', 'and', 'are', 'as', 'at', 'be', 'but', 'by', 'for', 'if', 'in', 'into', 'is', 'it',
+        'no', 'not', 'of', 'on', 'or', 'such', 'that', 'the', 'their', 'then', 'there', 'these', 'they',
+        'this', 'to', 'was', 'will', 'with',
+    ];
+
+    protected const SAMPLE_TEXT = "Machine learning is the study of computer algorithms that improve automatically through experience. It is seen as a subset of artificial intelligence. Machine learning algorithms build a mathematical model based on sample data, known as 'training data', in order to make predictions or decisions without being explicitly programmed to do so. Machine learning algorithms are used in a wide variety of applications, such as email filtering and computer vision, where it is difficult or infeasible to develop conventional algorithms to perform the needed tasks. Machine learning is closely related to computational statistics, which focuses on making predictions using computers. The study of mathematical optimization delivers methods, theory and application domains to the field of machine learning. Data mining is a related field of study, focusing on exploratory data analysis through unsupervised learning. In its application across business problems, machine learning is also referred to as predictive analytics.";
+
+    /**
+     * @var \Rubix\ML\Datasets\Unlabeled
+     */
+    protected $dataset;
+
+    /**
+     * @var \Rubix\ML\Transformers\StopWordFilter
+     */
+    protected $transformer;
+
+    public function setUp() : void
+    {
+        $k = (int) strlen(self::SAMPLE_TEXT) / 8;
+
+        $samples = [];
+
+        for ($i = 0; $i < self::DATASET_SIZE; ++$i) {
+            $samples[] = str_split(self::SAMPLE_TEXT, $k) ?: [];
+        }
+
+        $this->dataset = new Unlabeled($samples);
+
+        $this->transformer = new StopWordFilter(self::LUCENE_STOPWORDS_EN);
+    }
+
+    /**
+     * @Subject
+     * @Iterations(3)
+     * @OutputTimeUnit("milliseconds", precision=3)
+     */
+    public function apply() : void
+    {
+        $this->dataset->apply($this->transformer);
+    }
+}

--- a/src/Transformers/StopWordFilter.php
+++ b/src/Transformers/StopWordFilter.php
@@ -24,18 +24,23 @@ class StopWordFilter extends RegexFilter
      */
     public function __construct(array $stopWords = [])
     {
-        $patterns = [];
-
-        foreach ($stopWords as $word) {
-            if (!is_string($word)) {
+        foreach ($stopWords as &$word) {
+            if (!is_string($word) || empty($word)) {
                 throw new InvalidArgumentException('Stop word must be a'
-                    . ' string, ' . gettype($word) . ' found.');
+                    . 'non-empty string, ' . gettype($word) . ' found.');
             }
 
-            $patterns[] = '/\b' . preg_quote($word, '/') . '\b/u';
+            $word = preg_quote($word, '/');
         }
 
-        parent::__construct($patterns);
+        if (empty($stopWords)) {
+            throw new InvalidArgumentException('Must specify at least'
+                . ' 1 stop word');
+        }
+
+        $pattern = sprintf('/\b(%s)\b/u', implode('|', $stopWords));
+
+        parent::__construct([$pattern]);
     }
 
     /**


### PR DESCRIPTION
#### SUMMARY:

- Optimize the `StopWordFilter` implementation and provide a benchmark script. 

- <s>Add the default stopwords that lucene uses: [`apache-lucene`::`getDefaultStopSet()`](https://github.com/apache/lucene-solr/blob/master/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/EnglishAnalyzer.java#L46...L55)</s>



---

#### BENCHMARK:

The existing implementation completes in ~9 seconds, whilst the new implementation completes in ~1.3 seconds. The gain is achieved by using a single pattern to search for all the provided stopwords instead using separate patterns and passes to search for each individual stopword.

######  📉    EXISITING IMPLEMENTATION:
```
$ ./vendor/bin/phpbench run benchmarks/Transformers/StopWordFilterNormalizerBench.php --report=default
PhpBench. Running benchmarks.
Using configuration file: /Users/chris/Developer/github.com/simplechris/RubixML/phpbench.json.dist

\Rubix\ML\Benchmarks\Transformers\StopWordFilterNormalizerBench (#0 apply)

#0  9,841.620 9,757.097 9,627.247 (ms) [μ Mo]/r: 9,741.988 9,771.980 μRSD/r: 0.91%

1 subjects, 3 iterations, 1 revs, 0 rejects, 0 failures, 0 warnings
(best [mean mode] worst) = 9.627 [9.742 9.772] 9.842 (s)
⅀T: 29.226s μSD/r 0.088s μRSD/r: 0.905%
suite: 1343ddb0d29ec507359726bd15b23765d8438452, date: 2020-09-23, stime: 12:18:34
+-------------------------------+---------+-----+------+------+--------------+-------------+--------------+----------------+
| benchmark                     | subject | set | revs | iter | mem_peak     | time_rev    | comp_z_value | comp_deviation |
+-------------------------------+---------+-----+------+------+--------------+-------------+--------------+----------------+
| StopWordFilterNormalizerBench | apply   | 0   | 1    | 0    | 265,801,648b | 9,841.620ms | +1.13σ       | +1.02%         |
| StopWordFilterNormalizerBench | apply   | 0   | 1    | 1    | 265,801,648b | 9,757.097ms | +0.17σ       | +0.16%         |
| StopWordFilterNormalizerBench | apply   | 0   | 1    | 2    | 265,801,648b | 9,627.247ms | -1.3σ        | -1.18%         |
+-------------------------------+---------+-----+------+------+--------------+-------------+--------------+----------------+
```

⠀
######  📈    NEW IMPLEMENTATION:

```
$ ./vendor/bin/phpbench run benchmarks/Transformers/StopWordFilterNormalizerBench.php --report=default
PhpBench. Running benchmarks.
Using configuration file: /Users/chris/Developer/github.com/simplechris/RubixML/phpbench.json.dist

\Rubix\ML\Benchmarks\Transformers\StopWordFilterNormalizerBench (#0 apply)

#0  1,285.937 1,250.089 1,284.863 (ms) [μ Mo]/r: 1,273.630 1,283.271 μRSD/r: 1.31%

1 subjects, 3 iterations, 1 revs, 0 rejects, 0 failures, 0 warnings
(best [mean mode] worst) = 1.250 [1.274 1.283] 1.286 (s)
⅀T: 3.821s μSD/r 0.017s μRSD/r: 1.307%
suite: 1343ddb23cb4e6934212a6d152e82f3149636f2f, date: 2020-09-23, stime: 12:20:14
+-------------------------------+---------+-----+------+------+--------------+-------------+--------------+----------------+
| benchmark                     | subject | set | revs | iter | mem_peak     | time_rev    | comp_z_value | comp_deviation |
+-------------------------------+---------+-----+------+------+--------------+-------------+--------------+----------------+
| StopWordFilterNormalizerBench | apply   | 0   | 1    | 0    | 268,999,040b | 1,285.937ms | +0.74σ       | +0.97%         |
| StopWordFilterNormalizerBench | apply   | 0   | 1    | 1    | 268,999,040b | 1,250.089ms | -1.41σ       | -1.85%         |
| StopWordFilterNormalizerBench | apply   | 0   | 1    | 2    | 268,999,040b | 1,284.863ms | +0.67σ       | +0.88%         |
+-------------------------------+---------+-----+------+------+--------------+-------------+--------------+----------------+
```