### PR TITLE
fix BallTree edge case

### DIFF
--- a/src/Graph/Trees/BallTree.php
+++ b/src/Graph/Trees/BallTree.php
@@ -150,9 +150,14 @@ class BallTree implements BinaryTree, Spatial, Stringable
             if ($right->numRows() > $this->maxLeafSize) {
                 $node = Ball::split($right, $this->kernel);
 
-                $current->attachRight($node);
+                [$nleft, $nright] = $node->groups();
 
-                $stack[] = $node;
+                if ($left->empty() && $nleft->empty() && $right == $nright) {
+                    $current->attachRight(Clique::terminate($right, $this->kernel));
+                } else {
+                    $current->attachRight($node);
+                    $stack[] = $node;
+                }
             } elseif (!$right->empty()) {
                 $current->attachRight(Clique::terminate($right, $this->kernel));
             }

--- a/tests/Graph/Trees/BallTreeTest.php
+++ b/tests/Graph/Trees/BallTreeTest.php
@@ -2,6 +2,7 @@
 
 namespace Rubix\ML\Tests\Graph\Trees;
 
+use Tensor\Matrix;
 use Rubix\ML\Graph\Trees\Tree;
 use Rubix\ML\Graph\Trees\Spatial;
 use Rubix\ML\Graph\Trees\BallTree;
@@ -9,6 +10,7 @@ use Rubix\ML\Graph\Trees\BinaryTree;
 use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Kernels\Distance\Euclidean;
 use Rubix\ML\Datasets\Generators\Agglomerate;
+use Rubix\ML\Datasets\Labeled;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -80,6 +82,32 @@ class BallTreeTest extends TestCase
         $this->assertCount(25, $labels);
         $this->assertCount(25, $distances);
 
+        $this->assertCount(1, array_unique($labels));
+    }
+
+    /**
+     * @test
+     */
+    public function growWithRepetitions() : void
+    {
+        $size = 25;
+
+        $samples = Matrix::fill(0.5, $size, 3)->asArray();
+        $dataset = Labeled::quick($samples, array_fill(0, $size, 'test'));
+
+        $this->tree->grow($dataset);
+
+        $this->assertEquals(2, $this->tree->height());
+
+        $sample = $dataset->sample(0);
+
+        [$samples, $labels, $distances] = $this->tree->nearest($sample, 5);
+
+        $this->assertCount(5, $samples);
+        $this->assertCount(5, $labels);
+        $this->assertCount(5, $distances);
+
+        $this->assertCount(1, array_unique($samples, SORT_REGULAR));
         $this->assertCount(1, array_unique($labels));
     }
 


### PR DESCRIPTION
We had another infinite loop problem in BallTree. Whenever a dataset contained the same samples repeating more than the max leaf size BallTree::grow was trying to split the same tree over and over again - since all nodes were having the same left and right centeroid values, it kept all the samples in the right subtree and continued trying to split it. I added an exception handling code that terminated the process in that case. It can result with a leaf node containing more than max leaf size but I am not sure what else to do here - all the samples in that leaf are the same, so we don't have a criteria to further split them.

Added a test to cover this use-case. If you run the test without the fix in BallTree class, you will see an infinite loop occurs.

Let me know if you see other solutions here or any problems with this one. Thanks!