### PR TITLE
Optimize empty patterns case

### DIFF
--- a/benchmarks/Transformers/StopWordFilterBench.php
+++ b/benchmarks/Transformers/StopWordFilterBench.php
@@ -26,11 +26,6 @@ class StopWordFilterBench
      */
     protected $dataset;
 
-    /**
-     * @var \Rubix\ML\Transformers\StopWordFilter
-     */
-    protected $transformer;
-
     public function setUp() : void
     {
         $k = (int) strlen(self::SAMPLE_TEXT) / 8;
@@ -42,8 +37,6 @@ class StopWordFilterBench
         }
 
         $this->dataset = new Unlabeled($samples);
-
-        $this->transformer = new StopWordFilter(self::STOP_WORDS);
     }
 
     /**
@@ -53,6 +46,16 @@ class StopWordFilterBench
      */
     public function apply() : void
     {
-        $this->dataset->apply($this->transformer);
+        $this->dataset->apply(new StopWordFilter(self::STOP_WORDS));
+    }
+
+    /**
+     * @Subject
+     * @Iterations(3)
+     * @OutputTimeUnit("milliseconds", precision=3)
+     */
+    public function applyEmpty() : void
+    {
+        $this->dataset->apply(new StopWordFilter([]));
     }
 }

--- a/src/Transformers/RegexFilter.php
+++ b/src/Transformers/RegexFilter.php
@@ -122,6 +122,10 @@ class RegexFilter implements Transformer, Stringable
      */
     public function transform(array &$samples) : void
     {
+        if (empty($this->patterns)) {
+            return;
+        }
+
         foreach ($samples as &$sample) {
             foreach ($sample as &$value) {
                 if (is_string($value)) {

--- a/src/Transformers/StopWordFilter.php
+++ b/src/Transformers/StopWordFilter.php
@@ -24,6 +24,8 @@ class StopWordFilter extends RegexFilter
      */
     public function __construct(array $stopWords = [])
     {
+        $patterns = [];
+
         foreach ($stopWords as &$word) {
             if (!is_string($word) or empty($word)) {
                 throw new InvalidArgumentException('Stop word must be a'
@@ -33,9 +35,11 @@ class StopWordFilter extends RegexFilter
             $word = preg_quote($word, '/');
         }
 
-        $pattern = sprintf('/\b(%s)\b/u', implode('|', $stopWords));
+        if (!empty($stopWords)) {
+            $patterns[] = sprintf('/\b(%s)\b/u', implode('|', $stopWords));
+        }
 
-        parent::__construct([$pattern]);
+        parent::__construct($patterns);
     }
 
     /**


### PR DESCRIPTION
##### SUMMARY:

Just a quick one! By removing the checks for empty patterns in https://github.com/RubixML/RubixML/commit/2006467770f6d035fd3b5f97a83ec6d43a4c154c Some unnecessary iteration over the dataset now occurs in `RegexFilter::transform()`. 

It also has resulted in a slow pattern getting applied by the `StopWordFilter`. This PR is a quick fast follow to hopefully get in before `0.2.1` is tagged 🤞 .

###### 📉 CURRENT:
```
$ phpbench run benchmarks/Transformers/StopWordFilterBench.php --filter=applyEmpty --report=aggregate

\Rubix\ML\Benchmarks\Transformers\StopWordFilterBench (#0 applyEmpty)

#0  579.356 593.731 582.705 (ms) [μ Mo]/r: 585.264 582.057 μRSD/r: 1.05%

1 subjects, 3 iterations, 1 revs, 0 rejects, 0 failures, 0 warnings
(best [mean mode] worst) = 0.579 [0.585 0.582] 0.594 (s)
⅀T: 1.756s μSD/r 0.006s μRSD/r: 1.049%

+---------------------+------------+-----+------+-----+-------------+-----------+-----------+-----------+-----------+---------+--------+-------+
| benchmark           | subject    | set | revs | its | mem_peak    | best      | mean      | mode      | worst     | stdev   | rstdev | diff  |
+---------------------+------------+-----+------+-----+-------------+-----------+-----------+-----------+-----------+---------+--------+-------+
| StopWordFilterBench | applyEmpty | 0   | 1    | 3   | 34,290,208b | 579.356ms | 585.264ms | 582.057ms | 593.731ms | 6.141ms | 1.05%  | 1.00x |
+---------------------+------------+-----+------+-----+-------------+-----------+-----------+-----------+-----------+---------+--------+-------+
```

###### 📈 WITH FIX:

```
$ phpbench run benchmarks/Transformers/StopWordFilterBench.php --filter=applyEmpty --report=aggregate

\Rubix\ML\Benchmarks\Transformers\StopWordFilterBench (#0 applyEmpty)

#0  0.380 0.399 0.344 (ms) [μ Mo]/r: 0.374 0.384 μRSD/r: 6.09%

1 subjects, 3 iterations, 1 revs, 0 rejects, 0 failures, 0 warnings
(best [mean mode] worst) = 0.000 [0.000 0.000] 0.000 (s)
⅀T: 0.001s μSD/r 0.000s μRSD/r: 6.093%
+---------------------+------------+-----+------+-----+-------------+---------+---------+---------+---------+---------+--------+-------+
| benchmark           | subject    | set | revs | its | mem_peak    | best    | mean    | mode    | worst   | stdev   | rstdev | diff  |
+---------------------+------------+-----+------+-----+-------------+---------+---------+---------+---------+---------+--------+-------+
| StopWordFilterBench | applyEmpty | 0   | 1    | 3   | 22,965,272b | 0.344ms | 0.374ms | 0.384ms | 0.399ms | 0.023ms | 6.09%  | 1.00x |
+---------------------+------------+-----+------+-----+-------------+---------+---------+---------+---------+---------+--------+-------+
```