### PR TITLE
[RFC] Data Persistence in Rubix ML

### DIFF
--- a/src/Persisters/Filesystem.php
+++ b/src/Persisters/Filesystem.php
@@ -2,14 +2,9 @@
 
 namespace Rubix\ML\Persisters;
 
-use Rubix\ML\Encoding;
-use Rubix\ML\Persistable;
-use Rubix\ML\Other\Helpers\Params;
-use Rubix\ML\Persisters\Serializers\Native;
 use Rubix\ML\Persisters\Serializers\Serializer;
-use Rubix\ML\Exceptions\RuntimeException;
 
-use function is_file;
+use Rubix\ML\Storage\LocalFilesystem;
 
 /**
  * Filesystem
@@ -21,129 +16,19 @@ use function is_file;
  * @category    Machine Learning
  * @package     Rubix/ML
  * @author      Andrew DalPino
+ * @author      Chris Simpson
  */
-class Filesystem implements Persister
+class Filesystem extends HistoryPersister implements Persister
 {
     /**
-     * The extension to give files created as part of a persistable's save history.
+     * Creates a `Persister` backed by `\Rubix\ML\Storage\LocalFilesystem`
      *
-     * @var string
-     */
-    public const HISTORY_EXT = 'old';
-
-    /**
-     * The path to the model file on the filesystem.
-     *
-     * @var string
-     */
-    protected $path;
-
-    /**
-     * Should we keep a history of past saves?
-     *
-     * @var bool
-     */
-    protected $history;
-
-    /**
-     * The serializer used to convert to and from serial format.
-     *
-     * @var \Rubix\ML\Persisters\Serializers\Serializer
-     */
-    protected $serializer;
-
-    /**
-     * @param string $path
+     * @param string $location
      * @param bool $history
      * @param \Rubix\ML\Persisters\Serializers\Serializer|null $serializer
      */
-    public function __construct(string $path, bool $history = false, ?Serializer $serializer = null)
+    public function __construct(string $location, bool $history = false, ?Serializer $serializer = null)
     {
-        $this->path = $path;
-        $this->history = $history;
-        $this->serializer = $serializer ?? new Native();
-    }
-
-    /**
-     * Save the persistable object.
-     *
-     * @param \Rubix\ML\Persistable $persistable
-     * @throws \Rubix\ML\Exceptions\RuntimeException
-     */
-    public function save(Persistable $persistable) : void
-    {
-        if (!is_file($this->path) and !is_writable(dirname($this->path))) {
-            throw new RuntimeException('Folder does not exist or is not writable');
-        }
-
-        if (is_file($this->path) and !is_writable($this->path)) {
-            throw new RuntimeException("File {$this->path} is not writable.");
-        }
-
-        if ($this->history and is_file($this->path)) {
-            $timestamp = (string) time();
-
-            $filename = "{$this->path}-$timestamp." . self::HISTORY_EXT;
-
-            $num = 0;
-
-            while (file_exists($filename)) {
-                $filename = "{$this->path}-$timestamp-" . ++$num . '.' . self::HISTORY_EXT;
-            }
-
-            if (!rename($this->path, $filename)) {
-                throw new RuntimeException('Failed to create history file.');
-            }
-        }
-
-        $encoding = $this->serializer->serialize($persistable);
-
-        if ($encoding->bytes() === 0) {
-            throw new RuntimeException("Cannot save empty file to {$this->path}");
-        }
-
-        $success = file_put_contents($this->path, $encoding->data(), LOCK_EX);
-
-        if (!$success) {
-            throw new RuntimeException('Failed to write to the filesystem.');
-        }
-    }
-
-    /**
-     * Load the last saved persistable instance.
-     *
-     * @throws \Rubix\ML\Exceptions\RuntimeException
-     * @return \Rubix\ML\Persistable
-     */
-    public function load() : Persistable
-    {
-        if (!is_file($this->path)) {
-            throw new RuntimeException("File {$this->path} does not exist.");
-        }
-
-        if (!is_readable($this->path)) {
-            throw new RuntimeException("File {$this->path} is not readable.");
-        }
-
-        $encoding = new Encoding(file_get_contents($this->path) ?: '');
-
-        if ($encoding->bytes() === 0) {
-            throw new RuntimeException("File {$this->path} does not"
-                . ' contain any data.');
-        }
-
-        return $this->serializer->unserialize($encoding);
-    }
-
-    /**
-     * Return the string representation of the object.
-     *
-     * @return string
-     */
-    public function __toString() : string
-    {
-        return "Filesystem (path: {$this->path},"
-            . ' history: ' . Params::toString($this->history) . ','
-            . " serializer: {$this->serializer})";
+        parent::__construct($location, new LocalFilesystem(), $history, $serializer);
     }
 }

--- a/src/Persisters/HistoryPersister.php
+++ b/src/Persisters/HistoryPersister.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Rubix\ML\Persisters;
+
+use Rubix\ML\Encoding;
+use Rubix\ML\Other\Helpers\Params;
+use Rubix\ML\Persistable;
+use Rubix\ML\Persisters\Serializers\Native;
+use Rubix\ML\Persisters\Serializers\Serializer;
+use Rubix\ML\Storage\Datastore;
+use Rubix\ML\Storage\Exceptions\RuntimeException;
+use Rubix\ML\Storage\Streams\Stream;
+
+/**
+ * HistoryPersister
+ *
+ * HistoryPersister provides the logic to keep the save history of a `Persistable` object.
+ *
+ * @category    Machine Learning
+ * @package     Rubix/ML
+ * @author      Andrew DalPino
+ * @author      Chris Simpson
+ */
+abstract class HistoryPersister implements Persister
+{
+    protected const HISTORY_EXT = 'old';
+
+    /**
+     * @var string
+     */
+    protected $location;
+
+    /**
+     * @var Datastore
+     */
+    protected $storage;
+
+    /**
+     * @var bool
+     */
+    protected $history;
+
+    /**
+     * @var Serializer
+     */
+    protected $serializer;
+
+    /**
+     * @param string $location
+     * @param \Rubix\ML\Storage\Datastore $datastore
+     * @param bool $history
+     * @param \Rubix\ML\Persisters\Serializers\Serializer|null $serializer
+     */
+    public function __construct(string $location, Datastore $datastore, bool $history = true, ?Serializer $serializer = null)
+    {
+        $this->location = $location;
+        $this->storage = $datastore;
+        $this->history = $history;
+        $this->serializer = $serializer ?? new Native();
+    }
+
+    /**
+     * Save the persistable object.
+     *
+     * @param \Rubix\ML\Persistable $persistable
+     * @throws \Rubix\ML\Storage\Exceptions\StorageException
+     */
+    public function save(Persistable $persistable) : void
+    {
+        if ($this->history and $this->storage->exists($this->location)) {
+            $timestamp = (string) time();
+
+            $filename = "{$this->location}-$timestamp." . self::HISTORY_EXT;
+
+            $num = 0;
+
+            while ($this->storage->exists($filename)) {
+                $filename = "{$this->location}-$timestamp-" . ++$num . '.' . self::HISTORY_EXT;
+            }
+
+            $this->storage->move($this->location, $filename);
+        }
+
+        $encoding = $this->serializer->serialize($persistable);
+
+        if ($encoding->bytes() === 0) {
+            throw new RuntimeException("Cannot save empty encoding to {$this->location}");
+        }
+
+        $this->storage->write($this->location, $encoding->data());
+    }
+
+    /**
+     * Load the last saved persistable instance.
+     *
+     * @throws \Rubix\ML\Storage\Exceptions\StorageException
+     * @return \Rubix\ML\Persistable
+     */
+    public function load() : Persistable
+    {
+        if (!$this->storage->exists($this->location)) {
+            throw new RuntimeException("Target: '{$this->location}' does not exist.");
+        }
+
+        $stream = $this->storage->read($this->location, Stream::READ_ONLY);
+        $encoding = new Encoding($stream->contents());
+
+        if ($encoding->bytes() === 0) {
+            throw new RuntimeException("Target: '{$this->location}' does not"
+                . ' contain any data.');
+        }
+
+        return $this->serializer->unserialize($encoding);
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    protected function params() : array
+    {
+        return [
+            'path' => $this->location,
+            'history' => $this->history,
+            'serializer' => $this->serializer,
+        ];
+    }
+
+    /**
+     * Return the string representation of the object.
+     *
+     * @return string
+     */
+    public function __toString() : string
+    {
+        return Params::shortName(get_called_class()) .
+            ' (' . Params::stringify($this->params()) . ')';
+    }
+}

--- a/src/Persisters/Persister.php
+++ b/src/Persisters/Persister.php
@@ -11,12 +11,14 @@ interface Persister extends Stringable
      * Save the persistable object.
      *
      * @param \Rubix\ML\Persistable $persistable
+     * @throws \Rubix\ML\Storage\Exceptions\StorageException
      */
     public function save(Persistable $persistable) : void;
 
     /**
      * Load the last saved persistable instance.
      *
+     * @throws \Rubix\ML\Storage\Exceptions\StorageException
      * @return \Rubix\ML\Persistable
      */
     public function load() : Persistable;

--- a/src/Storage/Datastore.php
+++ b/src/Storage/Datastore.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rubix\ML\Storage;
+
+use Stringable;
+
+/**
+ * Datastore.
+ *
+ * Defines the behaviour of a generic storage repository (filesystem, database etc)
+ *
+ * @category    Machine Learning
+ * @package     Rubix/ML
+ * @author      Chris Simpson
+ */
+interface Datastore extends Reader, Writer, Stringable
+{
+    //
+}

--- a/src/Storage/Exceptions/ReadError.php
+++ b/src/Storage/Exceptions/ReadError.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rubix\ML\Storage\Exceptions;
+
+class ReadError extends RuntimeException implements StorageException
+{
+    //
+}

--- a/src/Storage/Exceptions/RuntimeException.php
+++ b/src/Storage/Exceptions/RuntimeException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rubix\ML\Storage\Exceptions;
+
+use Rubix\ML\Exceptions\RubixMLException;
+use Rubix\ML\Exceptions\RuntimeException as BaseRuntimeException;
+
+class RuntimeException extends BaseRuntimeException implements StorageException, RubixMLException
+{
+    //
+}

--- a/src/Storage/Exceptions/StorageException.php
+++ b/src/Storage/Exceptions/StorageException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rubix\ML\Storage\Exceptions;
+
+use Throwable;
+
+interface StorageException extends Throwable
+{
+    //
+}

--- a/src/Storage/Exceptions/WriteError.php
+++ b/src/Storage/Exceptions/WriteError.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rubix\ML\Storage\Exceptions;
+
+class WriteError extends RuntimeException implements StorageException
+{
+    //
+}

--- a/src/Storage/LocalFilesystem.php
+++ b/src/Storage/LocalFilesystem.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Rubix\ML\Storage;
+
+use Rubix\ML\Storage\Streams\File;
+use Rubix\ML\Storage\Streams\Stream;
+use Rubix\ML\Storage\Exceptions\RuntimeException;
+
+/**
+ * Local Datastore.
+ *
+ * @category    Machine Learning
+ * @package     Rubix/ML
+ * @author      Chris Simpson
+ */
+class LocalFilesystem implements Datastore
+{
+    /**
+     * @see \Rubix\ML\Storage\Reader::exists()
+     * @inheritdoc
+     *
+     * @param string $location
+     *
+     * @return bool
+     */
+    public function exists(string $location) : bool
+    {
+        return file_exists($location);
+    }
+
+    /**
+     * @see \Rubix\ML\Storage\Reader::read()
+     * @inheritdoc
+     *
+     * @param string $location
+     *
+     * @return \Rubix\ML\Storage\Streams\Stream
+     */
+    public function read(string $location, string $mode = Stream::READ_ONLY) : Stream
+    {
+        $resource = fopen($location, $mode);
+
+        if (!$resource) {
+            throw new RuntimeException("Could not open $location.");
+        }
+
+        $stream = new File($resource);
+
+        if (!$stream->readable()) {
+            throw new RuntimeException("Stream with mode {$mode} cannot be read from");
+        }
+
+        return $stream;
+    }
+
+    /**
+     * @see \Rubix\ML\Storage\Writer::write()
+     * @inheritdoc
+     *
+     * @param string $location
+     * @param \Rubix\ML\Storage\Streams\Stream|string $data
+     */
+    public function write(string $location, $data) : void
+    {
+        if ($data instanceof Stream) {
+            $data = $data->contents();
+        }
+
+        file_put_contents($location, $data, LOCK_EX);
+    }
+
+    /**
+     * @see \Rubix\ML\Storage\Writer::delete()
+     * @inheritdoc
+     *
+     * @param string $location
+     */
+    public function delete(string $location) : void
+    {
+        unlink($location);
+    }
+
+    /**
+     * @see \Rubix\ML\Storage\Writer::move()
+     * @inheritdoc
+     *
+     * @param string $from
+     * @param string $to
+     */
+    public function move(string $from, string $to) : void
+    {
+        rename($from, $to);
+    }
+
+    /**
+     * Return the string representation of the object.
+     *
+     * @return string
+     */
+    public function __toString() : string
+    {
+        return 'Local Filesystem';
+    }
+}

--- a/src/Storage/ReadProxy.php
+++ b/src/Storage/ReadProxy.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Rubix\ML\Storage;
+
+use Rubix\ML\Other\Helpers\Params;
+use Rubix\ML\Storage\Streams\Stream;
+
+/**
+ * Wraps a Datastore (that implements both Reader and Writer) to be used as a Reader.
+ *
+ * @category    Machine Learning
+ * @package     Rubix/ML
+ * @author      Chris Simpson
+ */
+class ReadProxy implements Reader
+{
+    /**
+     * @var \Rubix\ML\Storage\Reader
+     */
+    protected $storage;
+
+    /**
+     * @param \Rubix\ML\Storage\Reader $storage
+     */
+    public function __construct(Reader $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    /**
+     * Return if the target exists at $location.
+     *
+     * @param string $location
+     * @throws \Rubix\ML\Storage\Exceptions\StorageException
+     * @return bool
+     */
+    public function exists(string $location) : bool
+    {
+        return $this->storage->exists($location);
+    }
+
+    /**
+     * Open a stream of the target data at $location.
+     *
+     * @param string $location
+     * @param string $mode
+     * @throws \Rubix\ML\Storage\Exceptions\ReadError
+     * @throws \Rubix\ML\Storage\Exceptions\StorageException
+     * @return \Rubix\ML\Storage\Streams\Stream
+     */
+    public function read(string $location, string $mode = Stream::READ_ONLY) : Stream
+    {
+        return $this->storage->read($location, $mode);
+    }
+
+    /**
+     * Return the string representation of the object.
+     *
+     * @return string
+     */
+    public function __toString() : string
+    {
+        return 'Read Proxy (storage: ' . Params::toString($this->storage) . ')';
+    }
+}

--- a/src/Storage/Reader.php
+++ b/src/Storage/Reader.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rubix\ML\Storage;
+
+use Rubix\ML\Storage\Streams\Stream;
+
+/**
+ * Reader
+ *
+ * @category    Machine Learning
+ * @package     Rubix/ML
+ * @author      Chris Simpson
+ */
+interface Reader
+{
+    /**
+     * Return if the target exists at $location.
+     *
+     * @param string $location
+     * @throws \Rubix\ML\Storage\Exceptions\StorageException
+     * @return bool
+     */
+    public function exists(string $location) : bool;
+
+    /**
+     * Open a stream of the target data at $location.
+     *
+     * @param string $location
+     * @param string $mode
+     * @throws \Rubix\ML\Storage\Exceptions\ReadError
+     * @throws \Rubix\ML\Storage\Exceptions\StorageException
+     * @return \Rubix\ML\Storage\Streams\Stream
+     */
+    public function read(string $location, string $mode = Stream::READ_ONLY) : Stream;
+}

--- a/src/Storage/Streams/File.php
+++ b/src/Storage/Streams/File.php
@@ -1,0 +1,405 @@
+<?php
+
+namespace Rubix\ML\Storage\Streams;
+
+use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Other\Helpers\Params;
+use Rubix\ML\Storage\Exceptions\WriteError;
+use Rubix\ML\Storage\Exceptions\RuntimeException;
+use Generator;
+
+/**
+ * Stream.
+ *
+ * @category    Machine Learning
+ * @package     Rubix/ML
+ * @author      Chris Simpson
+ */
+class File implements Stream
+{
+    /**
+     * @var int
+     */
+    protected const DEFAULT_BUFFER = 1048576;
+
+    /**
+     * @var array
+     */
+    protected const MODES = [
+        'readable' => [
+            'a+' => true, 'a+b' => true, 'a+t' => true,
+            'c+' => true, 'c+b' => true, 'c+t' => true,
+            'r' => true, 'r+' => true, 'r+b' => true,
+            'r+t' => true, 'rb' => true, 'rt' => true,
+            'w+' => true, 'w+b' => true, 'w+t' => true,
+            'x+' => true, 'x+b' => true, 'x+t' => true,
+        ],
+        'writable' => [
+            'a' => true, 'a+' => true, 'a+b' => true,
+            'a+t' => true, 'ab' => true, 'at' => true,
+            'c' => true, 'c+' => true, 'c+b' => true,
+            'c+t' => true, 'cb' => true, 'ct' => true,
+            'r+' => true, 'r+b' => true, 'r+t' => true,
+            'w' => true, 'w+' => true, 'w+b' => true,
+            'w+t' => true, 'wb' => true, 'wt' => true,
+            'x' => true, 'x+' => true, 'x+b' => true,
+            'x+t' => true, 'xb' => true, 'xt' => true,
+        ],
+    ];
+
+    /**
+     * @var resource
+     */
+    protected $stream;
+
+    /**
+     * @var int
+     */
+    protected $buffer;
+
+    /**
+     * @var bool
+     */
+    protected $open;
+
+    /**
+     * @param mixed $input
+     * @param string $mode
+     * @param int $buffer
+     * @throws \InvalidArgumentException
+     * @return \Rubix\ML\Storage\Streams\Stream
+     */
+    public static function factory($input, string $mode = Stream::READ_WRITE, int $buffer = self::DEFAULT_BUFFER) : Stream
+    {
+        $type = gettype($input);
+
+        if ($type == 'string' or ($type === 'object' and method_exists($input, '__toString'))) {
+            $resource = self::resource((string) $input, $mode);
+
+            return new self($resource, $buffer);
+        }
+
+        throw new InvalidArgumentException("Could not make stream from type: $type");
+    }
+
+    /**
+     * @param string $contents
+     * @param string $mode
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
+     * @throws \Rubix\ML\Storage\Exceptions\RuntimeException
+     * @return resource
+     */
+    public static function resource(string $contents, string $mode = Stream::READ_WRITE)
+    {
+        if (!array_key_exists($mode, self::MODES['readable']) and !array_key_exists($mode, self::MODES['writable'])) {
+            throw new InvalidArgumentException("Unsupported mode: {$mode}");
+        }
+
+        $stream = fopen('php://temp', $mode);
+
+        if (!$stream) {
+            throw new RuntimeException('Could not create stream buffer');
+        }
+
+        fwrite($stream, $contents);
+        rewind($stream);
+
+        return $stream;
+    }
+
+    /**
+     * @param resource|mixed $stream
+     * @param int $buffer
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
+     */
+    public function __construct($stream, int $buffer = self::DEFAULT_BUFFER)
+    {
+        if (!is_resource($stream)) {
+            throw new InvalidArgumentException('Stream requires a resource');
+        }
+
+        $this->stream = $stream;
+        $this->buffer = $buffer;
+        $this->open = true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function open() : bool
+    {
+        return $this->open;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function metadata() : array
+    {
+        return stream_get_meta_data($this->stream);
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $fallback
+     *
+     * @return mixed
+     */
+    public function meta(string $key, $fallback = '')
+    {
+        switch ($key) {
+            case 'readable':
+                return array_key_exists($this->mode(), self::MODES['readable']);
+
+            case 'writable':
+                return array_key_exists($this->mode(), self::MODES['writable']);
+
+            default:
+                return ($this->metadata()[$key] ?? $fallback) ?: $fallback;
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function mode() : string
+    {
+        return strtolower((string) $this->meta('mode'));
+    }
+
+    /**
+     * @return bool
+     */
+    public function readable() : bool
+    {
+        return (bool) $this->meta('readable');
+    }
+
+    /**
+     * @return bool
+     */
+    public function writable() : bool
+    {
+        return (bool) $this->meta('writable');
+    }
+
+    /**
+     * @return bool
+     */
+    public function seekable() : bool
+    {
+        return (bool) $this->meta('seekable');
+    }
+
+    /**
+     * Read one line from the stream.
+     *
+     * @param ?int $length
+     * @param string $ending
+     *
+     * @return string
+     */
+    public function line(?int $length = null, string $ending = PHP_EOL)
+    {
+        $this->assertReadable();
+
+        return (string) stream_get_line($this->stream, $length ?? $this->buffer, $ending);
+    }
+
+    /**
+     * Read bytes from the stream.
+     *
+     * @param ?int $length
+     * @return string
+     */
+    public function read(?int $length = null) : string
+    {
+        $this->assertReadable();
+
+        $bytes = fread($this->stream, $length ?? $this->buffer);
+
+        if ($bytes === false) {
+            throw new RuntimeException('Cannot read stream');
+        }
+
+        return $bytes;
+    }
+
+    /**
+     * Read the remaining data from the stream until EOF.
+     *
+     * @throws \Rubix\ML\Storage\Exceptions\RuntimeException
+     * @return string
+     */
+    public function contents() : string
+    {
+        $this->assertReadable();
+        $contents = stream_get_contents($this->stream);
+
+        if (false === $contents) {
+            throw new RuntimeException('Could not get contents of stream');
+        }
+
+        return $contents;
+    }
+
+    /**
+     * Check for end-of-file on the internal file pointer
+     *
+     * @see https://www.php.net/manual/en/function.feof.php
+     *
+     * @return bool
+     */
+    public function eof() : bool
+    {
+        return feof($this->stream);
+    }
+
+    /**
+     * Write data to the stream.
+     *
+     * @see https://www.php.net/manual/en/function.fwrite.php
+     *
+     * @param string $data The string that is to be written.
+     * @throws \Rubix\ML\Storage\Exceptions\RuntimeException
+     * @return int Number of bytes written
+     */
+    public function write(string $data) : int
+    {
+        $this->assertWritable();
+        $bytes = fwrite($this->stream, $data);
+
+        if (false === $bytes) {
+            throw new RuntimeException('Could not write to stream');
+        }
+
+        return $bytes;
+    }
+
+    /**
+     * Get the position of the file pointer.
+     *
+     * @see https://www.php.net/manual/en/function.ftell.php
+     *
+     * @throws \Rubix\ML\Storage\Exceptions\RuntimeException
+     * @return int
+     */
+    public function tell() : int
+    {
+        $this->assertSeekable();
+        $offset = ftell($this->stream);
+
+        if (false === $offset) {
+            throw new RuntimeException('Could not get offset of stream');
+        }
+
+        return $offset;
+    }
+
+    /**
+     * Move the file pointer to a new position
+     *
+     * @see https://php.net/manual/en/function.fseek.php
+     *
+     * @param int $offset
+     * @param int $whence
+     *
+     * @throws \Rubix\ML\Storage\Exceptions\RuntimeException
+     */
+    public function seek(int $offset, int $whence = SEEK_SET) : void
+    {
+        $this->assertSeekable();
+
+        if (0 !== fseek($this->stream, $offset, $whence)) {
+            throw new RuntimeException('Could not seek on stream');
+        }
+    }
+
+    /**
+     * Move the file pointer to the beginning of the stream.
+     *
+     * @see https://php.net/manual/en/function.rewind.php
+     */
+    public function rewind() : void
+    {
+        $this->assertSeekable();
+
+        if (false === rewind($this->stream)) {
+            throw new RuntimeException('Could not rewind stream');
+        }
+    }
+
+    /**
+     * Close the pointer to the stream.
+     *
+     * @see https://php.net/manual/en/function.fclose.php
+     */
+    public function close() : void
+    {
+        if (!$this->open) {
+            throw new WriteError('Cannot close stream: already closed');
+        }
+
+        if (!fclose($this->stream)) {
+            throw new RuntimeException('Could not close stream');
+        }
+
+        $this->open = false;
+    }
+
+    /**
+     * @return Generator<string>
+     */
+    public function getIterator() : Generator
+    {
+        while (!$this->eof() and $this->open) {
+            yield $this->line();
+        }
+    }
+
+    protected function assertReadable() : void
+    {
+        if (!$this->open) {
+            throw new WriteError('Cannot read from a closed stream');
+        }
+
+        if (!$this->readable()) {
+            throw new WriteError('Cannot read from a stream with mode:' . $this->meta('mode'));
+        }
+    }
+
+    protected function assertWritable() : void
+    {
+        if (!$this->open) {
+            throw new WriteError('Cannot write to a closed stream');
+        }
+
+        if (!$this->writable()) {
+            throw new WriteError('Cannot write to a stream with mode:' . $this->meta('mode'));
+        }
+    }
+
+    protected function assertSeekable() : void
+    {
+        if (!$this->open) {
+            throw new WriteError('Cannot seek on a closed stream');
+        }
+
+        if (!$this->seekable()) {
+            throw new WriteError('Cannot seek on a non-seekable stream');
+        }
+    }
+
+    public function __toString() : string
+    {
+        $params = [
+            'mode' => $this->mode(),
+            'open' => $this->open(),
+            'readable' => $this->readable(),
+            'writable' => $this->writable(),
+            'seekable' => $this->seekable(),
+        ];
+
+        return 'Stream : (' . Params::stringify(array_merge($params, $this->metadata())) . ')';
+    }
+}

--- a/src/Storage/Streams/Stream.php
+++ b/src/Storage/Streams/Stream.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Rubix\ML\Storage\Streams;
+
+use Generator;
+use IteratorAggregate;
+use Stringable;
+
+use const PHP_EOL;
+use const SEEK_SET;
+
+/**
+ * Stream.
+ *
+ * @category    Machine Learning
+ * @package     Rubix/ML
+ * @author      Chris Simpson
+ *
+ * @extends \IteratorAggregate<string>
+ */
+interface Stream extends IteratorAggregate, Stringable
+{
+    /**
+     * @var string
+     */
+    public const READ_ONLY = 'r';
+
+    /**
+     * @var string
+     */
+    public const READ_WRITE = 'r+';
+
+    /**
+     * @var string
+     */
+    public const WRITE_ONLY = 'w';
+
+    /**
+     * @return bool
+     */
+    public function open() : bool;
+
+    /**
+     * @return array<mixed>
+     */
+    public function metadata() : array;
+
+    /**
+     * @param string $key
+     * @param mixed $fallback
+     * @return mixed
+     */
+    public function meta(string $key, $fallback = '');
+
+    /**
+     * @return string
+     */
+    public function mode() : string;
+
+    /**
+     * @return bool
+     */
+    public function readable() : bool;
+
+    /**
+     * @return bool
+     */
+    public function writable() : bool;
+
+    /**
+     * @return bool
+     */
+    public function seekable() : bool;
+
+    /**
+     * Read one line from the stream.
+     *
+     * @param ?int $length
+     * @param string $ending
+     * @return string
+     */
+    public function line(?int $length = null, string $ending = PHP_EOL);
+
+    /**
+     * Read bytes from the stream.
+     *
+     * @param ?int $length
+     * @return string
+     */
+    public function read(?int $length = null) : string;
+
+    /**
+     * Read the remaining data from the stream until EOF.
+     *
+     * @throws \Rubix\ML\Storage\Exceptions\RuntimeException
+     * @return string
+     */
+    public function contents() : string;
+
+    /**
+     * Check for end-of-file on the internal file pointer
+     *
+     * @see https://www.php.net/manual/en/function.feof.php
+     *
+     * @return bool
+     */
+    public function eof() : bool;
+
+    /**
+     * Write data to the stream. Return the number of bytes written
+     *
+     * @see https://www.php.net/manual/en/function.fwrite.php
+     *
+     * @param string $data
+     *
+     * @throws \Rubix\ML\Storage\Exceptions\RuntimeException
+     * @return int
+     */
+    public function write(string $data) : int;
+
+    /**
+     * Get the position of the file pointer.
+     *
+     * @see https://www.php.net/manual/en/function.ftell.php
+     *
+     * @throws \Rubix\ML\Storage\Exceptions\RuntimeException
+     * @return int
+     */
+    public function tell() : int;
+
+    /**
+     * Move the file pointer to a new position
+     *
+     * @see https://php.net/manual/en/function.fseek.php
+     *
+     * @param int $offset
+     * @param int $whence
+     *
+     * @throws \Rubix\ML\Storage\Exceptions\RuntimeException
+     */
+    public function seek(int $offset, int $whence = SEEK_SET) : void;
+
+    /**
+     * Move the file pointer to the beginning of the stream.
+     *
+     * @see https://php.net/manual/en/function.rewind.php
+     */
+    public function rewind() : void;
+
+    /**
+     * Close the pointer to the stream.
+     *
+     * @see https://php.net/manual/en/function.fclose.php
+     */
+    public function close() : void;
+
+    /**
+     * @return Generator<string>
+     */
+    public function getIterator() : Generator;
+}

--- a/src/Storage/WriteProxy.php
+++ b/src/Storage/WriteProxy.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Rubix\ML\Storage;
+
+use Rubix\ML\Other\Helpers\Params;
+
+/**
+ * Wraps a Datastore (that implements both Reader and Writer) to be used as a Writer.
+ *
+ * @category    Machine Learning
+ * @package     Rubix/ML
+ * @author      Chris Simpson
+ */
+class WriteProxy implements Writer
+{
+    /**
+     * @var \Rubix\ML\Storage\Writer
+     */
+    protected $storage;
+
+    public function __construct(Writer $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    /**
+     * @param string $location
+     * @param mixed $data
+     * @throws \Rubix\ML\Storage\Exceptions\WriteError
+     * @throws \Rubix\ML\Storage\Exceptions\StorageException
+     */
+    public function write(string $location, $data) : void
+    {
+        $this->storage->write($location, $data);
+    }
+
+    /**
+     * @param string $from
+     * @param string $to
+     * @throws \Rubix\ML\Storage\Exceptions\StorageException
+     */
+    public function move(string $from, string $to) : void
+    {
+        $this->storage->move($from, $to);
+    }
+
+    /**
+     * Delete.
+     *
+     * @param string $location
+     * @throws \Rubix\ML\Storage\Exceptions\StorageException
+     */
+    public function delete(string $location) : void
+    {
+        $this->storage->delete($location);
+    }
+
+    /**
+     * Return the string representation of the object.
+     *
+     * @return string
+     */
+    public function __toString() : string
+    {
+        return 'Write Proxy (storage: ' . Params::toString($this->storage) . ')';
+    }
+}

--- a/src/Storage/Writer.php
+++ b/src/Storage/Writer.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rubix\ML\Storage;
+
+/**
+ * Writer
+ *
+ * @category    Machine Learning
+ * @package     Rubix/ML
+ * @author      Chris Simpson
+ */
+interface Writer
+{
+    /**
+     * Write.
+     *
+     * @param string $location
+     * @param mixed $data
+     * @throws \Rubix\ML\Storage\Exceptions\WriteError
+     * @throws \Rubix\ML\Storage\Exceptions\StorageException
+     */
+    public function write(string $location, $data) : void;
+
+    /**
+     * Move.
+     *
+     * NOTE: If supported by the underlying datastore this should be implemented as an atomic operation.
+     *
+     * @param string $from
+     * @param string $to
+     * @throws \Rubix\ML\Storage\Exceptions\StorageException
+     */
+    public function move(string $from, string $to) : void;
+
+    /**
+     * Delete.
+     *
+     * @param string $location
+     * @throws \Rubix\ML\Storage\Exceptions\StorageException
+     */
+    public function delete(string $location) : void;
+}


### PR DESCRIPTION
<table width="100%">
  <tr><th>✏️</th><td><b>[RFC] Data Persistence in Rubix ML</b></td></tr>
  <tr><th>👨‍💻 </th><td> <a href="https://github.com/simplechris">Chris Simpson</a> </td></tr>
  <tr><th>🗓 </th><td>September - October 2020</td></tr>
</table>

---

#### BACKGROUND:

It is very common for a user of the RubixML library to load or save data. 

Within RubixML most actions relating to [data persistence](https://en.wikipedia.org/wiki/Persistence_(computer_science)) are typically achieved via the use of [`Persister`](https://docs.rubixml.com/en/latest/persisters/api.html#persisters) either directly, or via the [`PersistentModel`](https://docs.rubixml.com/en/latest/persistent-model.html) class. The purpose of a [`Persister`](https://docs.rubixml.com/en/latest/persisters/api.html#persisters) is to _save_ a new [`Persistable`](https://docs.rubixml.com/en/latest/persistable.html) object or to _load_ a previously saved object.

Whilst a [`Persister`](https://docs.rubixml.com/en/latest/persisters/api.html#persisters) handles the persistence of objects (recursively [de]serializing the objects and their internal dependencies), the more-general action of _reading_ or _writing_ data also appears in numerous other places within the library e.g. The [`Encoding`](https://github.com/RubixML/RubixML/blob/master/src/Encoding.php) object has a [`write()`](https://github.com/RubixML/RubixML/blob/master/src/Encoding.php#L51) method used to _write_ data to the local filesystem, whilst the purpose of [`Extractors`](https://docs.rubixml.com/en/latest/extractors/api.html#extractors) is to _read_ data and transform it into [`Dataset`](https://docs.rubixml.com/en/latest/datasets/api.html#dataset-objects) objects.

**This contribution aims to introduce abstractions for data IO suitable for use across the entire codebase. It standardizes the mechanism of how data is persisted (saved/loaded) within RubixML.**

#### DESIGN GOALS:

- Remove any tight-coupling to the local file system: Introduce a new abstraction modelling where data can be stored (local filesystem, remote/cloud storage, database etc). The default location can remain as the local filesystem, but alternative implementations should be used if provided.
- Split the responsibility of _reading_ and _writing_ data. By design [`Extractors`](https://docs.rubixml.com/en/latest/extractors/api.html#extractors) should be read-only, whilst [`Encoding`](https://github.com/RubixML/RubixML/blob/master/src/Encoding.php) objects need only have awareness of how to _write_ the data that they contain.
- Retain the simplicity and of the [`Persister`](https://docs.rubixml.com/en/latest/persisters/api.html) interface, whilst introducing lower-level abstractions to power _all_ current and future data storage operations.
- Allow for the incremental and memory-efficient reading and writing of data via the use of [steams](https://www.php.net/manual/en/intro.stream.phphttps://www.php.net/manual/en/intro.stream.php) and [generators](https://www.php.net/manual/en/language.generators.overview.php) wherever possible/practical.

#### APPROACH:

This PR introduces the `Rubix\ML\Storage` namespace. This namespace contains abstractions relating to _reading_ and _writing_ of data: `Datastore` defines the behaviour of a generic data-storage repository. It is given the ability to perform _read_-related operations via the `Rubix\Ml\Storage\Reader` interface, and it's ability to perform _write_-related operations from the `Rubix\Ml\Storage\Writer` interface. A `Datastore` fully implements both of these interfaces. This separation allows for `Reader` to be type-hinted where read-only behaviour is intended. `Writer` to be used where the class only wishes to _write_ data. `Datastore` that encompasses both `Reader` and `Writer` can be hinted to classes that require both mechanisms (eg `Persister` implementations).


##### `Reader`:

```php
<?php

namespace Rubix\ML\Storage;

use Rubix\ML\Storage\Streams\Stream;

/**
 * Reader
 *
 * @category    Machine Learning
 * @package     Rubix/ML
 * @author      Chris Simpson
 */
interface Reader
{
    /**
     * Return if the target exists at $location.
     *
     * @param string $location
     * @throws \Rubix\ML\Storage\Exceptions\StorageException
     * @return bool
     */
    public function exists(string $location) : bool;

    /**
     * Open a stream of the target data at $location.
     *
     * @param string $location
     * @param string $mode
     * @throws \Rubix\ML\Storage\Exceptions\ReadError
     * @throws \Rubix\ML\Storage\Exceptions\StorageException
     * @return \Rubix\ML\Storage\Streams\Stream
     */
    public function read(string $location, string $mode = Stream::READ_ONLY) : Stream;
}

```


##### `Writer`:

```php
<?php

namespace Rubix\ML\Storage;

/**
 * Writer
 *
 * @category    Machine Learning
 * @package     Rubix/ML
 * @author      Chris Simpson
 */
interface Writer
{
    /**
     * Write.
     *
     * @param string $location
     * @param mixed $data
     * @throws \Rubix\ML\Storage\Exceptions\WriteError
     * @throws \Rubix\ML\Storage\Exceptions\StorageException
     */
    public function write(string $location, $data) : void;

    /**
     * Move.
     *
     * NOTE: If supported by the underlying datastore this should be implemented as an atomic operation.
     *
     * @param string $from
     * @param string $to
     * @throws \Rubix\ML\Storage\Exceptions\StorageException
     */
    public function move(string $from, string $to) : void;

    /**
     * Delete.
     *
     * @param string $location
     * @throws \Rubix\ML\Storage\Exceptions\StorageException
     */
    public function delete(string $location) : void;
}

```

##### `Datastore`:

```php
<?php

namespace Rubix\ML\Storage;

use Stringable;

/**
 * Datastore.
 *
 * Defines the behaviour of a generic storage repository (filesystem, database etc)
 *
 * @category    Machine Learning
 * @package     Rubix/ML
 * @author      Chris Simpson
 */
interface Datastore extends Reader, Writer, Stringable
{
    //
}

```



##### `Stream`:

`Reader::read()` returns an object implementing the `Stream` interface. This interface acts as an [OO](https://en.wikipedia.org/wiki/Object-oriented_programming) wrapper around php [streams](https://www.php.net/manual/en/intro.stream.php). This functionality is explicitly wrapped to enable typehinting (`resource` is not a valid language-level typehint), and for consistent non repetitive stream interaction. `Stream` represents a generic stream of data and implements all common stream operations via methods named after the common semantics used.

The `Stream` interface enables the ability to incrementally (in a 'cursorable' manner) read the data from the underlying resource, and also implements [`IteratorAggregate`](https://www.php.net/manual/en/class.iteratoraggregate.php) allowing the object to be iterated upon directly (yielding a line of content per iteration) Note: To read the entire contents of the stream in a single operation see `Stream::contents()`.

#### INTEGRATION:

To illustrate the implementation and integration of these new objects I have provided an example: `Rubix\ML\Storage\LocalFilesystem`. This is the simplest of implementations and can be used to replace any existing interaction with data stored on the local filesystem for example `Extractor` implementations, `Encoding` objects, and the widely used `Filesystem` Persistor class.

##### `Rubix\ML\Storage\LocalFilesystem`:

```php
<?php

namespace Rubix\ML\Storage;

use Rubix\ML\Storage\Streams\File;
use Rubix\ML\Storage\Streams\Stream;
use Rubix\ML\Storage\Exceptions\RuntimeException;

/**
 * Local Datastore.
 *
 * @category    Machine Learning
 * @package     Rubix/ML
 * @author      Chris Simpson
 */
class LocalFilesystem implements Datastore
{
    /**
     * @see \Rubix\ML\Storage\Reader::exists()
     * @inheritdoc
     *
     * @param string $location
     *
     * @return bool
     */
    public function exists(string $location) : bool
    {
        return file_exists($location);
    }

    /**
     * @see \Rubix\ML\Storage\Reader::read()
     * @inheritdoc
     *
     * @param string $location
     *
     * @return \Rubix\ML\Storage\Streams\Stream
     */
    public function read(string $location, string $mode = Stream::READ_ONLY) : Stream
    {
        $resource = fopen($location, $mode);

        if (!$resource) {
            throw new RuntimeException("Could not open $location.");
        }

        $stream = new File($resource);

        if (!$stream->readable()) {
            throw new RuntimeException("Stream with mode {$mode} cannot be read from");
        }

        return $stream;
    }

    /**
     * @see \Rubix\ML\Storage\Writer::write()
     * @inheritdoc
     *
     * @param string $location
     * @param \Rubix\ML\Storage\Streams\Stream|string $data
     */
    public function write(string $location, $data) : void
    {
        if ($data instanceof Stream) {
            $data = $data->contents();
        }

        file_put_contents($location, $data, LOCK_EX);
    }

    /**
     * @see \Rubix\ML\Storage\Writer::delete()
     * @inheritdoc
     *
     * @param string $location
     */
    public function delete(string $location) : void
    {
        unlink($location);
    }

    /**
     * @see \Rubix\ML\Storage\Writer::move()
     * @inheritdoc
     *
     * @param string $from
     * @param string $to
     */
    public function move(string $from, string $to) : void
    {
        rename($from, $to);
    }

    /**
     * Return the string representation of the object.
     *
     * @return string
     */
    public function __toString() : string
    {
        return 'Local Filesystem';
    }
}

```

##### `Encoding`:

The `Encoding::write()` method now accepts an optional second parameter of type `Rubix\ML\Storage\Writer`. Omitting this argument will cause an instance of `Rubix\ML\Storage\LocalFilesystem` to be used (so existing behaviour is transparently maintained resulting in no BC breaks)

##### `Extractors`:

By design, `Extractor` objects are [read-only](https://en.wikipedia.org/wiki/File-system_permissions). All existing implementations now accept a `Reader` in their constructors and the implementations have been updated to show how the `Stream` object returned by `Reader::read(): Stream` can be used in-place of the existing semantics. 

*Note:* Any `Reader` implementation can be used: so `Extractors` are now decoupled from the local filesystem and able to read data from a multitude of storage backends.

---

#### DISCUSSION:

Whilst I have given this implementation considerable thought, and gone though numerous iterations prior to opening this PR, I still think there is room for a significant discussion here. The specific implementations here are intended as illustrative and I'm most interested in feedback on the design itself. I have a number of open questions myself, but think that this is mature enough to introduce external feedback and inspection.

- **Naming is hard.** Whilst I've tried to be as concise as possible I think there is room to improve the naming of these abstractions! Which is preferable: `Datastore`? `Repository`? `StorageOperator`, `StorageEngine` etc? Happy to take suggestions! I would have initially used `Backend` but obviously didn't want to cause any confusion with the [`Backend`](https://docs.rubixml.com/en/latest/parallel.html#set-a-backend) interface used in the parallel processing.

- **Future proof?** I've tried to make these abstractions generic and multi-purpose. If you can anticipate a future use-case that wouldn't be supported then let's discuss.

- **Backwards Compatibility**: Have I broken anything? Should I have? Let's talk about the options here.

- **Unit Tests**: Whilst all current unit tests are passing, I have purposefully neglected to add further tests prior to confirming the design/discussion/direction in this PR.

- **Exceptions**: The exceptions were added prior to the merge of https://github.com/RubixML/RubixML/pull/116 so are more a rudimentary demonstration of potential flexibility and not a active recommendation of how we should structure an exception hierarchy.

- **Pull Request**: At the time of writing I have based this PR against `0.3.0`, as it contains the most up-to-date 'nightly' code. This is just to minimise the size of the diff.

---
#### RELATED:
- https://github.com/RubixML/RubixML/issues/108: How can the persistence subsystem be extended across the codebase? This was my starting point for this PR. I realized that Persisters are actually very good at what they do (serializing objects and storing them) and backing them by the common storage abstractions (without changing the `Persister` interface) would be a positive step forwards.
- A early proof-of-concept showing how storage could be made pluggable using `Flysystem 1.x`: https://github.com/RubixML/RubixML/pull/106.
- A Persistor backed by `Flysystem 2.x` (beta): https://github.com/RubixML/Extras/pull/3


#### REVISIONS:

###### `2020-10-05`:
- Initial publish and request for comments.