### PR TITLE
Word Tokenizer namespace typo

### DIFF
--- a/docs/other/tokenizers/word.md
+++ b/docs/other/tokenizers/word.md
@@ -8,7 +8,7 @@ This tokenizer does not have any parameters.
 
 ## Example
 ```php
-use Rubix\ML\Extractors\Tokenizers\Word;
+use Rubix\ML\Other\Tokenizers\Word;
 
 $tokenizer = new Word();
 ```


### PR DESCRIPTION
Fix Word Tokenizer namespace typo 