### PR TITLE
Flysystem Persister

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,11 @@
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/polyfill-php73": "^1.20",
         "symfony/polyfill-php80": "^1.17",
-        "league/flysystem": "2.0.0-beta.3"
+        "league/flysystem": "~2.0.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.16.*",
+        "league/flysystem-memory": "^2.0",
         "phpbench/phpbench": "0.17.*",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "0.12.*",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "rubix/tensor": "^2.0",
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/polyfill-php73": "^1.20",
-        "symfony/polyfill-php80": "^1.17"
+        "symfony/polyfill-php80": "^1.17",
+        "league/flysystem": "2.0.0-beta.3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.16.*",

--- a/docs/persisters/flysystem.md
+++ b/docs/persisters/flysystem.md
@@ -1,0 +1,94 @@
+<span style="float:right;"><a href="https://github.com/RubixML/RubixML/blob/master/src/Persisters/Flysystem.php">[source]</a></span>
+
+# Flysystem
+[Flysystem](https://flysystem.thephpleague.com) is a filesystem abstraction library providing a unified interface for 
+[many different filesystems](https://github.com/thephpleague/flysystem#adapters). It enables access to remote storage backends such as Amazon S3, Azure Blob Storage, Google Cloud Storage, Dropbox...
+
+The Flysystem persister saves models to a file at a given path using the Flysystem library, and can automatically keep a history of past saved models.
+
+## Parameters
+| # | Param | Default | Type | Description |
+|---|---|---|---|---|
+| 1 | path | | string | The path to the model file on the filesystem. |
+| 2 | filesystem |  | FilesystemInterface | The flysystem object providing access to your storage backend |
+| 3 | serializer | Native | Serializer | The serializer used to convert to and from storage format. |
+
+## Examples
+
+### Local:
+ Using the Flysystem Persister to interact with data stored on your local filesystem:
+- Pass the Flysystem Persister a `Filesystem` object that uses the `Local` adapter instance:
+```php
+use League\Flysystem\Filesystem;
+use League\Flysystem\Adapter\Local;
+use Rubix\ML\Persisters\Flysystem;
+
+$storage = new Filesystem(new Local('/'));
+$persister = new Flysystem('/path/to/example.model', $storage);
+
+// Or, to save keystrokes you could also use the shortcut method:
+
+$persister = Flysystem::local('/path/to/example.model');
+```
+
+### FTP Server:
+Using the Flysystem Persister to interact with data stored on an FTP Server:
+- Pass the Flysystem Persister a `Filesystem` object that uses the `Ftp` adapter instance:
+
+```php
+use League\Flysystem\Filesystem;
+use League\Flysystem\Adapter\Ftp;
+use Rubix\ML\Persisters\Flysystem;
+
+$config = [
+    'host' => 'ftp.example.com',
+    'username' => 'username',
+    'password' => 'password',
+];
+$storage = new Filesystem(new Ftp($config));
+$persister = new Flysystem('/path/to/example.model', $storage);
+
+// Or, to save keystrokes you could also use the shortcut method:
+
+$persister = Flysystem::ftp('/path/to/example.model', $config);
+```
+
+### Amazon S3
+Using the Flysystem Persister to interact with data on Amazon S3:
+- install the Flysystem S3 adapter: `composer require league/flysystem-aws-s3-v3`
+- Pass the Flysystem Persister a `Filesystem` object that uses the `AwsS3Adapter` adapter instance:
+
+```php
+use Aws\S3\S3Client;
+use League\Flysystem\Filesystem;
+use League\Flysystem\AwsS3v3\AwsS3Adapter;
+use Rubix\ML\Persisters\Flysystem;
+
+$client = new S3Client([
+    'credentials' => [
+        'key'    => 'your-key',
+        'secret' => 'your-secret',
+    ],
+    'region' => 'your-region',
+    'version' => 'latest|version',
+]);
+
+$storage = new Filesystem(new AwsS3Adapter($client, 'your-bucket-name'));
+
+$persister = new Flysystem('/path/to/example.model', $storage);
+```
+
+
+## Additional Methods
+
+Shortcut to return a Flysystem Persister backed by the [Local](https://flysystem.thephpleague.com/v1/docs/adapter/local/) filesystem
+
+```php
+public static local(string $path, bool $history = false, ?Serializer $serializer = null) : self
+```
+
+Shortcut to return a Flysystem Persister backed by an [FTP Server](https://flysystem.thephpleague.com/v1/docs/adapter/ftp/).
+
+```php
+public static ftp(string $path, array $config, bool $history = false, ?Serializer $serializer = null) : self
+```

--- a/docs/persisters/flysystem.md
+++ b/docs/persisters/flysystem.md
@@ -1,94 +1,29 @@
 <span style="float:right;"><a href="https://github.com/RubixML/RubixML/blob/master/src/Persisters/Flysystem.php">[source]</a></span>
 
 # Flysystem
-[Flysystem](https://flysystem.thephpleague.com) is a filesystem abstraction library providing a unified interface for 
-[many different filesystems](https://github.com/thephpleague/flysystem#adapters). It enables access to remote storage backends such as Amazon S3, Azure Blob Storage, Google Cloud Storage, Dropbox...
+[Flysystem](https://flysystem.thephpleague.com) is a filesystem library providing a unified storage interface and abstraction layer. It enables access to many different storage backends such as Local, Amazon S3, FTP, and more.
 
-The Flysystem persister saves models to a file at a given path using the Flysystem library, and can automatically keep a history of past saved models.
+> **Note:** The Flysystem persister is designed to work with Flysystem version 2.0.
 
 ## Parameters
 | # | Param | Default | Type | Description |
 |---|---|---|---|---|
-| 1 | path | | string | The path to the model file on the filesystem. |
-| 2 | filesystem |  | FilesystemInterface | The flysystem object providing access to your storage backend |
-| 3 | serializer | Native | Serializer | The serializer used to convert to and from storage format. |
+| 1 | path | | string | The path to the persistable object file on the filesystem. |
+| 2 | filesystem |  | FilesystemOperator | The Flysystem filesystem operator responsible for read and write operations. |
+| 3 | history | false | bool | Should we keep a history of past saves? |
+| 4 | serializer | Native | Serializer | The serializer used to convert to and from storage format. |
 
-## Examples
-
-### Local:
- Using the Flysystem Persister to interact with data stored on your local filesystem:
-- Pass the Flysystem Persister a `Filesystem` object that uses the `Local` adapter instance:
+## Example
 ```php
 use League\Flysystem\Filesystem;
-use League\Flysystem\Adapter\Local;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 use Rubix\ML\Persisters\Flysystem;
+use Rubix\ML\Persisters\Serializers\Native;
 
-$storage = new Filesystem(new Local('/'));
-$persister = new Flysystem('/path/to/example.model', $storage);
+$filesystem = new Filesystem(new LocalFilesystemAdapter('/path/to/'));
 
-// Or, to save keystrokes you could also use the shortcut method:
-
-$persister = Flysystem::local('/path/to/example.model');
+$persister = new Flysystem('example.model', $filesystem, true, new Native());
 ```
-
-### FTP Server:
-Using the Flysystem Persister to interact with data stored on an FTP Server:
-- Pass the Flysystem Persister a `Filesystem` object that uses the `Ftp` adapter instance:
-
-```php
-use League\Flysystem\Filesystem;
-use League\Flysystem\Adapter\Ftp;
-use Rubix\ML\Persisters\Flysystem;
-
-$config = [
-    'host' => 'ftp.example.com',
-    'username' => 'username',
-    'password' => 'password',
-];
-$storage = new Filesystem(new Ftp($config));
-$persister = new Flysystem('/path/to/example.model', $storage);
-
-// Or, to save keystrokes you could also use the shortcut method:
-
-$persister = Flysystem::ftp('/path/to/example.model', $config);
-```
-
-### Amazon S3
-Using the Flysystem Persister to interact with data on Amazon S3:
-- install the Flysystem S3 adapter: `composer require league/flysystem-aws-s3-v3`
-- Pass the Flysystem Persister a `Filesystem` object that uses the `AwsS3Adapter` adapter instance:
-
-```php
-use Aws\S3\S3Client;
-use League\Flysystem\Filesystem;
-use League\Flysystem\AwsS3v3\AwsS3Adapter;
-use Rubix\ML\Persisters\Flysystem;
-
-$client = new S3Client([
-    'credentials' => [
-        'key'    => 'your-key',
-        'secret' => 'your-secret',
-    ],
-    'region' => 'your-region',
-    'version' => 'latest|version',
-]);
-
-$storage = new Filesystem(new AwsS3Adapter($client, 'your-bucket-name'));
-
-$persister = new Flysystem('/path/to/example.model', $storage);
-```
-
 
 ## Additional Methods
-
-Shortcut to return a Flysystem Persister backed by the [Local](https://flysystem.thephpleague.com/v1/docs/adapter/local/) filesystem
-
-```php
-public static local(string $path, bool $history = false, ?Serializer $serializer = null) : self
-```
-
-Shortcut to return a Flysystem Persister backed by an [FTP Server](https://flysystem.thephpleague.com/v1/docs/adapter/ftp/).
-
-```php
-public static ftp(string $path, array $config, bool $history = false, ?Serializer $serializer = null) : self
-```
+This persister does not have any additional methods.

--- a/src/Persisters/Flysystem.php
+++ b/src/Persisters/Flysystem.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Rubix\ML\Persisters;
+
+use League;
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Adapter\Ftp;
+use League\Flysystem\FilesystemInterface;
+use Rubix\ML\Encoding;
+use Rubix\ML\Persistable;
+use Rubix\ML\Other\Helpers\Params;
+use Rubix\ML\Persisters\Serializers\Native;
+use Rubix\ML\Persisters\Serializers\Serializer;
+use RuntimeException;
+use Stringable;
+
+/**
+ * Flysystem
+ *
+ * The flysystem persister serializes models to a file at a user-specified path, using a
+ * user-provided flysystem instance.
+ *
+ * Flysystem is a filesystem abstraction providing a unified interface for many different
+ * filesystems. (Local, Amazon S3, Azure Blob Storage, Google Cloud Storage, Dropbox etc...)
+ *
+ * @see https://flysystem.thephpleague.com
+ *
+ * @category    Machine Learning
+ * @package     Rubix/ML
+ * @author      Chris Simpson
+ */
+class Flysystem implements Persister, Stringable
+{
+    /**
+     * The extension to give files created as part of a persistable's save history.
+     *
+     * @var string
+     */
+    public const HISTORY_EXT = 'old';
+
+    /**
+     * The path to the model file on the filesystem.
+     *
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * The filesystem implementation providing access to your backend storage.
+     *
+     * @var \League\Flysystem\FilesystemInterface
+     */
+    protected $filesystem;
+
+    /**
+     * Should we keep a history of past saves?
+     *
+     * @var bool
+     */
+    protected $history;
+
+    /**
+     * The serializer used to convert to and from serial format.
+     *
+     * @var \Rubix\ML\Persisters\Serializers\Serializer
+     */
+    protected $serializer;
+
+    /**
+     * Local
+     *
+     * Shortcut to return a Flysystem Persister backed by the Local filesystem
+     *
+     * @see https://flysystem.thephpleague.com/v1/docs/adapter/local/
+     *
+     * @param string $path The absolute path to the file on the filesystem.
+     * @param bool $history
+     * @param \Rubix\ML\Persisters\Serializers\Serializer|null $serializer
+     * @return \Rubix\ML\Persisters\Flysystem
+     */
+    public static function local(string $path, bool $history = false, ?Serializer $serializer = null) : Flysystem
+    {
+        $filesystem = new League\Flysystem\Filesystem(new Local(dirname($path)));
+
+        return new Flysystem(basename($path), $filesystem, $history, $serializer);
+    }
+
+    /**
+     * FTP
+     *
+     * Shortcut to return a Flysystem Persister backed by an FTP Server
+     *
+     * @see https://flysystem.thephpleague.com/v1/docs/adapter/ftp/
+     *
+     * @param string $path
+     * @param array<mixed> $config Configuration settings for the FTP adapter.
+     * @param bool $history
+     * @param \Rubix\ML\Persisters\Serializers\Serializer|null $serializer
+     * @return \Rubix\ML\Persisters\Flysystem
+     */
+    public static function ftp(string $path, array $config, bool $history = false, ?Serializer $serializer = null) : Flysystem
+    {
+        $filesystem = new League\Flysystem\Filesystem(new Ftp($config));
+
+        return new Flysystem($path, $filesystem, $history, $serializer);
+    }
+
+    /**
+     * @param string $path
+     * @param FilesystemInterface $filesystem
+     * @param bool $history
+     * @param \Rubix\ML\Persisters\Serializers\Serializer|null $serializer
+     */
+    public function __construct(string $path, FilesystemInterface $filesystem, bool $history = false, ?Serializer $serializer = null)
+    {
+        $this->path = $path;
+        $this->filesystem = $filesystem;
+        $this->history = $history;
+        $this->serializer = $serializer ?? new Native();
+    }
+
+    /**
+     * Save the persistable model.
+     *
+     * @param \Rubix\ML\Persistable $persistable
+     * @throws \RuntimeException
+     */
+    public function save(Persistable $persistable) : void
+    {
+        if ($this->history and $this->filesystem->has($this->path)) {
+            $timestamp = (string) time();
+
+            $filename = $this->path . '-' . $timestamp . '.' . self::HISTORY_EXT;
+
+            $num = 0;
+            while ($this->filesystem->has($filename)) {
+                $filename = $this->path . '-' . $timestamp . '-' . ++$num . '.' . self::HISTORY_EXT;
+            }
+
+            try {
+                if (!$this->filesystem->rename($this->path, $filename)) {
+                    throw new RuntimeException("Failed to create history file: '{$filename}' {$this}");
+                }
+            } catch (League\Flysystem\Exception $e) {
+                throw new RuntimeException("Failed to create history file: '{$filename}' {$this}");
+            }
+        }
+
+        $data = $this->serializer->serialize($persistable);
+        $success = $this->filesystem->put($this->path, (string) $data);
+
+        if (!$success) {
+            throw new RuntimeException("Could not write to filesystem. {$this}");
+        }
+    }
+
+    /**
+     * Load the last model that was saved.
+     *
+     * @throws \RuntimeException
+     * @return \Rubix\ML\Persistable
+     */
+    public function load() : Persistable
+    {
+        if (!$this->filesystem->has($this->path)) {
+            throw new RuntimeException("File does not exist in filesystem. {$this}");
+        }
+
+        $data = new Encoding($this->filesystem->read($this->path) ?: '');
+
+        if ($data->bytes() === 0) {
+            throw new RuntimeException("File does not contain any data. {$this}");
+        }
+
+        return $this->serializer->unserialize($data);
+    }
+
+    /**
+     * Return the string representation of the object.
+     *
+     * @return string
+     */
+    public function __toString() : string
+    {
+        $filesystem = 'Flysystem';
+
+        if (method_exists($this->filesystem, 'getAdapter')) {
+            $filesystem .= ' <' . Params::toString($this->filesystem->getAdapter()) . '>';
+        }
+
+        return "{$filesystem} (path: '{$this->path}', serializer: {$this->serializer})";
+    }
+}

--- a/tests/Persisters/FlysystemTest.php
+++ b/tests/Persisters/FlysystemTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Rubix\ML\Tests\Persisters;
+
+use League\Flysystem\FileNotFoundException;
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemInterface;
+use League\Flysystem\Memory\MemoryAdapter;
+use Rubix\ML\Persistable;
+use Rubix\ML\Persisters\Flysystem;
+use Rubix\ML\Persisters\Persister;
+use Rubix\ML\Classifiers\DummyClassifier;
+use RuntimeException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group Persisters
+ * @covers \Rubix\ML\Persisters\Flysystem
+ */
+class FlysystemTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    const PATH = '/path/to/test.model';
+
+    /**
+     * @var \League\Flysystem\FilesystemInterface
+     */
+    protected $filesystem;
+
+    /**
+     * @var \Rubix\ML\Persistable
+     */
+    protected $persistable;
+
+    /**
+     * @var \Rubix\ML\Persisters\Flysystem
+     */
+    protected $persister;
+
+    /**
+     * @before
+     */
+    protected function setUp() : void
+    {
+        $this->filesystem = new Filesystem(new MemoryAdapter());
+        $this->persistable = new DummyClassifier();
+        $this->persister = new Flysystem(self::PATH, $this->filesystem);
+    }
+
+    /**
+     * @after
+     */
+    protected function tearDown() : void
+    {
+        if ($this->filesystem->has(self::PATH)) {
+            $this->filesystem->delete(self::PATH);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function build() : void
+    {
+        $this->assertInstanceOf(Flysystem::class, $this->persister);
+        $this->assertInstanceOf(Persister::class, $this->persister);
+    }
+
+    /**
+     * @test
+     */
+    public function saveLoad() : void
+    {
+        $this->persister->save($this->persistable);
+        $this->assertTrue($this->filesystem->has(self::PATH));
+
+        $model = $this->persister->load();
+
+        $this->assertInstanceOf(DummyClassifier::class, $model);
+        $this->assertInstanceOf(Persistable::class, $model);
+    }
+
+    /**
+     * @test
+     */
+    public function testSaveMethodWhenFilesystemWriteFails() : void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('(^Could not write to filesystem)');
+
+        $filesystem = $this->createMock(FilesystemInterface::class);
+        $filesystem->method('put')->with(self::PATH)->willReturn(false); // false: WRITE FAILED
+
+        $this->persister = new Flysystem(self::PATH, $filesystem);
+        $this->persister->save($this->persistable);
+    }
+
+    /**
+     * @test
+     */
+    public function testSaveMethodWithHistoryDisabled() : void
+    {
+        $directory = dirname(self::PATH);
+        $this->persister = new Flysystem(self::PATH, $this->filesystem, false);
+
+        // Save
+        $this->persister->save($this->persistable);
+        $this->assertCount(1, $this->filesystem->listContents($directory));
+        $this->assertTrue($this->filesystem->has(self::PATH));
+
+        // Save again. As history is disabled the existing model will be overwritten:
+        $this->persister->save($this->persistable);
+        $this->assertCount(1, $this->filesystem->listContents($directory));
+        $this->assertTrue($this->filesystem->has(self::PATH));
+    }
+
+    /**
+     * @test
+     */
+    public function testSaveMethodWithHistoryEnabled() : void
+    {
+        $directory = dirname(self::PATH);
+        $this->persister = new Flysystem(self::PATH, $this->filesystem, true);
+
+        // Save
+        $this->persister->save($this->persistable);
+        $this->assertTrue($this->filesystem->has(self::PATH));
+
+        // Save again to the same path. The existing model will be renamed before saving the new model:
+        $this->persister->save($this->persistable);
+        $files = $this->filesystem->listContents($directory);
+        $this->assertCount(2, $files);
+        foreach ($files as $file) {
+            $this->assertStringContainsString(self::PATH, '/' . $file['path']);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function testSaveMethodWhenHistoryCreationFails() : void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('(^Failed to create history file:)');
+
+        $mock = $this->createMock(FilesystemInterface::class);
+        $mock->expects($this->any())
+            ->method('has')
+            ->willReturn($this->onConsecutiveCalls(true, true, false));
+        $mock->expects($this->any())
+            ->method('rename')
+            ->willReturn(false);
+
+        $this->persister = new Flysystem(self::PATH, $mock, true);
+        $this->persister->save($this->persistable);
+    }
+
+    /**
+     * @test
+     */
+    public function testSaveMethodWhenHistoryCreationInternallyFails() : void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('(^Failed to create history file:)');
+
+        $mock = $this->createMock(FilesystemInterface::class);
+        $mock->expects($this->any())
+            ->method('has')
+            ->willReturn($this->onConsecutiveCalls(true, true, false));
+        $mock->expects($this->any())
+            ->method('rename')
+            ->willThrowException(new FileNotFoundException(self::PATH));
+
+        $this->persister = new Flysystem(self::PATH, $mock, true);
+        $this->persister->save($this->persistable);
+    }
+
+    /**
+     * @test
+     */
+    public function testLoadMethodWhenTargetNotExists() : void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('(^File does not exist in filesystem)');
+
+        $this->persister->load();
+    }
+
+    /**
+     * @test
+     */
+    public function testLoadMethodWhenTargetIsEmpty() : void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('(^File does not contain any data)');
+
+        $this->filesystem->put(self::PATH, '');
+        $this->persister->load();
+    }
+
+    protected function assertPreConditions() : void
+    {
+        $this->assertFalse($this->filesystem->has(self::PATH));
+    }
+}


### PR DESCRIPTION
##### SUMMARY:

Introduces the Flysystem Persister, again :)

This PR has been extracted from commits in https://github.com/RubixML/RubixML/pull/107 and https://github.com/RubixML/RubixML/pull/109. I've patched them together to ensure the correct author attribution is maintained. It adds a [Flysystem](https://flysystem.thephpleague.com) [`Persistor`](https://docs.rubixml.com/en/latest/persisters/api.html). This enables a user to load and save models located in a remote storage backend (such as Amazon S3, Azure Blob Storage, Google Cloud Storage, Dropbox etc...)



This functionality previously lived over in the `RubixML/Extras` repo as we were waiting for the Flysystem 2 stable release. Now that thee is a stable release this can move into the main repo 🎉