### PR TITLE
Add INF/NAN converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- 1.4.0
+  - Added reversible converter for INF/NAN constants
+    
 - 1.3.2
     - Optimize Binary output layer
 

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -70,12 +70,13 @@ Oftentimes, the continuous features of a dataset will be on different scales bec
 ### Feature Conversion
 Feature converters are transformers that convert feature columns of one data type to another by changing their representation.
 
-| Transformer | From | To | [Stateful](transformers/api.md#stateful) | [Elastic](transformers/api.md#elastic) |
-|---|---|---|---|---|
-| [Interval Discretizer](transformers/interval-discretizer.md) | Continuous | Categorical | ● | |
-| [One Hot Encoder](transformers/one-hot-encoder.md) | Categorical | Continuous | ● | |
-| [Numeric String Converter](transformers/numeric-string-converter.md) | Categorical | Continuous | | |
-| [Boolean Converter](transformers/boolean-converter.md) | Other | Categorical or Continuous | | |
+| Transformer                                                          | From | To                        | [Stateful](transformers/api.md#stateful) | [Elastic](transformers/api.md#elastic) |
+|----------------------------------------------------------------------|---|---------------------------|---|---|
+| [Interval Discretizer](transformers/interval-discretizer.md)         | Continuous | Categorical               | ● | |
+| [One Hot Encoder](transformers/one-hot-encoder.md)                   | Categorical | Continuous                | ● | |
+| [Numeric String Converter](transformers/numeric-string-converter.md) | Categorical | Continuous                | | |
+| [Boolean Converter](transformers/boolean-converter.md)               | Other | Categorical or Continuous | | |
+| [INF/NAN Converter](transformers/inf-nan-converter.md)               | Other | Other                        | | |
 
 ### Dimensionality Reduction
 Dimensionality reduction is a preprocessing technique for projecting a dataset onto a lower dimensional vector space. It allows a learner to train and infer quicker by producing a training set with fewer but more informative features. Dimensionality reducers can also be used to visualize datasets by outputting low (1 - 3) dimensionality embeddings for use in plotting software.

--- a/docs/transformers/inf-nan-converter.md
+++ b/docs/transformers/inf-nan-converter.md
@@ -1,0 +1,31 @@
+<span style="float:right;"><a href="https://github.com/RubixML/ML/blob/master/src/Transformers/InfNanConverter.php">[source]</a></span>
+
+# INF/NAN converter
+This transformer is used to convert `NAN` and `INF` constants (both positive and negative) to their arbitrary string 
+equivalent and back. The main goal of the converter is transforming dataset samples before sending them as JSON request
+(`json_encode` does not support these constants). The transformer is reversible, so after receiving the samples you 
+can decode the constants back.
+
+**Interfaces:** [Transformer](api.md#transformer), [Reversible](api.md#reversible)
+
+**Data Type Compatibility:** Categorical, Continuous
+
+## Example
+Client side:
+```php
+use Rubix\ML\Transformers\InfNanConverter;
+
+$dataset->apply(new InfNanConverter());
+// now you can encode $dataset->samples() and send as part of a JSON HTTP request.
+```
+
+Client side:
+```php
+use Rubix\ML\Transformers\InfNanConverter;
+
+// build $dataset from decoded JSON payload and reverse apply the converter to get constant values back.
+$dataset->reverseApply(new InfNanConverter());
+```
+
+## Additional Methods
+This transformer does not have any additional methods.

--- a/src/Transformers/InfNanConverter.php
+++ b/src/Transformers/InfNanConverter.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Rubix\ML\Transformers;
+
+use Rubix\ML\DataType;
+
+use function is_nan;
+use function is_infinite;
+
+/**
+ * INF/NAN Constants Converter
+ *
+ * Converts INF/NAN constant values to their strings and back.
+ *
+ * @category    Machine Learning
+ * @package     Rubix/ML
+ * @author      Alex Torchenko
+ */
+class InfNanConverter implements Transformer, Reversible
+{
+    private const NAN_STRING_VALUE = '~~NAN~~';
+
+    private const INF_STRING_VALUE = '~~INF~~';
+
+    private const NEGATIVE_INF_STRING_VALUE = '~~-INF~~';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function compatibility() : array
+    {
+        return DataType::all();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function transform(array &$samples) : void
+    {
+        array_walk($samples, [$this, 'convert']);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function reverseTransform(array &$samples) : void
+    {
+        array_walk($samples, [$this, 'reverseConvert']);
+    }
+
+    /**
+     * Convert INF/NAN constants to their string equivalents.
+     *
+     * @param list<mixed> $sample
+     */
+    private function convert(array &$sample) : void
+    {
+        foreach ($sample as &$value) {
+            if (!is_float($value)) {
+                continue;
+            }
+
+            if (is_nan($value)) {
+                $value = self::NAN_STRING_VALUE;
+            } elseif (is_infinite($value) && $value > 0) {
+                $value = self::INF_STRING_VALUE;
+            } elseif (is_infinite($value) && $value < 0) {
+                $value = self::NEGATIVE_INF_STRING_VALUE;
+            }
+        }
+    }
+
+    /**
+     * Convert INF/NAN string values to their constant equivalents.
+     *
+     * @param list<mixed> $sample
+     */
+    private function reverseConvert(array &$sample) : void
+    {
+        foreach ($sample as &$value) {
+            if ($value === self::NAN_STRING_VALUE) {
+                $value = NAN;
+            } elseif ($value === self::INF_STRING_VALUE) {
+                $value = INF;
+            } elseif ($value === self::NEGATIVE_INF_STRING_VALUE) {
+                $value = -INF;
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __toString() : string
+    {
+        return 'INF/NAN constants converter';
+    }
+}

--- a/tests/Transformers/InfNanConverterTest.php
+++ b/tests/Transformers/InfNanConverterTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Rubix\ML\Tests\Transformers;
+
+use Rubix\ML\Datasets\Unlabeled;
+use Rubix\ML\Transformers\InfNanConverter;
+use Rubix\ML\Transformers\Reversible;
+use Rubix\ML\Transformers\Transformer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group Transformers
+ * @covers \Rubix\ML\Transformers\InfNanConverter
+ */
+class InfNanConverterTest extends TestCase
+{
+    /**
+     * @var \Rubix\ML\Datasets\Unlabeled
+     */
+    protected $dataset;
+
+    /**
+     * @var \Rubix\ML\Transformers\InfNanConverter
+     */
+    protected $transformer;
+
+    /**
+     * @var array<mixed[]>
+     */
+    protected $samples = [
+        [1, 'abc', true, INF, -INF, NAN],
+        [2, 'def', false, -INF, NAN, 0],
+    ];
+
+    /**
+     * @before
+     */
+    protected function setUp() : void
+    {
+        $this->dataset = new Unlabeled($this->samples);
+        $this->transformer = new InfNanConverter();
+    }
+
+    /**
+     * @test
+     */
+    public function build() : void
+    {
+        $this->assertInstanceOf(InfNanConverter::class, $this->transformer);
+        $this->assertInstanceOf(Transformer::class, $this->transformer);
+        $this->assertInstanceOf(Reversible::class, $this->transformer);
+    }
+
+    /**
+     * @test
+     */
+    public function transform() : void
+    {
+        $this->dataset->apply($this->transformer);
+
+        $this->assertEquals([
+            [1, 'abc', true, '~~INF~~', '~~-INF~~', '~~NAN~~'],
+            [2, 'def', false, '~~-INF~~', '~~NAN~~', 0],
+        ], $this->dataset->samples());
+    }
+
+    /**
+     * @test
+     */
+    public function reverseTransform() : void
+    {
+        $this->dataset->apply($this->transformer);
+        $this->dataset->reverseApply($this->transformer);
+
+        // Can't compare array due to NAN values
+        $this->assertEquals(1, $this->dataset->samples()[0][0]);
+        $this->assertEquals('abc', $this->dataset->samples()[0][1]);
+        $this->assertEquals(true, $this->dataset->samples()[0][2]);
+        $this->assertEquals(INF, $this->dataset->samples()[0][3]);
+        $this->assertEquals(-INF, $this->dataset->samples()[0][4]);
+        $this->assertTrue(is_nan($this->dataset->samples()[0][5]));
+
+        $this->assertEquals(2, $this->dataset->samples()[1][0]);
+        $this->assertEquals('def', $this->dataset->samples()[1][1]);
+        $this->assertEquals(false, $this->dataset->samples()[1][2]);
+        $this->assertEquals(-INF, $this->dataset->samples()[1][3]);
+        $this->assertTrue(is_nan($this->dataset->samples()[1][4]));
+        $this->assertEquals(0, $this->dataset->samples()[1][5]);
+    }
+}


### PR DESCRIPTION
### Problem
[RubixML Client](https://github.com/RubixML/Client) is currently not able to send requests with samples that contain `INF` and `NAN` constants as `json_encode` function does not support serialization of these values.

### Workaround
I suggest adding a new reversible transformer that would be used to convert the constants to some arbitrary values on the client side. Then the server will decode the payload and reverse apply the transformation to get constants back.

### Pull requests
- [x] Add new transformer to `ML` (this PR)
- [ ] Apply transformation on the [Client](https://github.com/RubixML/Client) side
- [ ] Apply reverse transformation on the [Server](https://github.com/RubixML/Server) side