### PR TITLE
Better visualization of decision trees (fixes #136)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,10 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,
-        "process-timeout": 3000
+        "process-timeout": 3000,
+        "allow-plugins": {
+            "phpstan/extension-installer": false
+        }
     },
     "funding": [
         {

--- a/composer.json
+++ b/composer.json
@@ -92,10 +92,7 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,
-        "process-timeout": 3000,
-        "allow-plugins": {
-            "phpstan/extension-installer": false
-        }
+        "process-timeout": 3000
     },
     "funding": [
         {

--- a/src/Graph/Nodes/Outcome.php
+++ b/src/Graph/Nodes/Outcome.php
@@ -15,5 +15,10 @@ use Stringable;
  */
 interface Outcome extends Decision, Stringable
 {
-    //
+    /**
+     * Return the outcome of the decision, depends on the actual class.
+     *
+     * @return mixed
+     */
+    public function outcome();
 }

--- a/src/Graph/Trees/DecisionTree.php
+++ b/src/Graph/Trees/DecisionTree.php
@@ -391,10 +391,10 @@ abstract class DecisionTree implements BinaryTree, IteratorAggregate
         $thisNode = $nodesCounter++;
 
         if ($depth == $maxDepth) {
-            $carry .= "N$thisNode [label=\"...\"];" . PHP_EOL;
+            $carry .= "  N$thisNode [label=\"...\"];" . PHP_EOL;
         } elseif ($node instanceof Split) {
             $operator = is_string($node->value()) ? '==' : '<';
-            $carry .= "N$thisNode [label=\"Column_{$node->column()} $operator {$node->value()}\"];" . PHP_EOL;
+            $carry .= "  N$thisNode [label=\"Column_{$node->column()} $operator {$node->value()}\"];" . PHP_EOL;
 
             if ($node->left() !== null) {
                 $this->_rules($carry, $nodesCounter, $maxDepth, $node->left(), $thisNode, 1, $depth);
@@ -404,7 +404,7 @@ abstract class DecisionTree implements BinaryTree, IteratorAggregate
                 $this->_rules($carry, $nodesCounter, $maxDepth, $node->right(), $thisNode, 2, $depth);
             }
         } elseif ($node instanceof Outcome) {
-            $carry .= "N$thisNode [label=\"Outcome={$node->outcome()}";
+            $carry .= "  N$thisNode [label=\"Outcome={$node->outcome()}";
 
             if ($node->impurity() > 0.0) {
                 $carry .= "\\nImpurity={$node->impurity()}";
@@ -413,7 +413,7 @@ abstract class DecisionTree implements BinaryTree, IteratorAggregate
         }
 
         if (!is_null($parentId)) {
-            $carry .= "N$parentId -> N$thisNode";
+            $carry .= "  N$parentId -> N$thisNode";
 
             if ($parentId == 0) {
                 $carry .= ' [labeldistance=2.5, ';
@@ -425,24 +425,6 @@ abstract class DecisionTree implements BinaryTree, IteratorAggregate
                 }
             }
             $carry .= ';' . PHP_EOL;
-        }
-    }
-
-    /**
-     * Return a generator for all the nodes in the tree starting at the root.
-     *
-     * @return \Generator<\Rubix\ML\Graph\Nodes\Decision>
-     */
-    protected function dump() : Generator
-    {
-        $stack = [$this->root];
-
-        while ($current = array_pop($stack)) {
-            yield $current;
-
-            foreach ($current->children() as $child) {
-                $stack[] = $child;
-            }
         }
     }
 }

--- a/tests/Classifiers/ClassificationTreeTest.php
+++ b/tests/Classifiers/ClassificationTreeTest.php
@@ -197,9 +197,9 @@ class ClassificationTreeTest extends TestCase
         $this->assertGreaterThanOrEqual(self::MIN_SCORE, $score);
 
         $dot = $this->estimator->exportGraphviz();
-        $this->assertEquals(strlen($dot), 3425);
+        $this->assertEquals(strlen($dot), 3217);
         $this->assertMatchesRegularExpression('/  N13 -> N17/', $dot);
-        $this->assertMatchesRegularExpression('/  N39.*label.*Outcome=blue.*style=.rounded/', $dot);
+        $this->assertMatchesRegularExpression('/  N39.*label.*blue.*style=.rounded/', $dot);
     }
 
     /**

--- a/tests/Classifiers/ClassificationTreeTest.php
+++ b/tests/Classifiers/ClassificationTreeTest.php
@@ -197,9 +197,9 @@ class ClassificationTreeTest extends TestCase
         $this->assertGreaterThanOrEqual(self::MIN_SCORE, $score);
 
         $dot = $this->estimator->rules();
-        $this->assertEquals(strlen($dot), 2599);
-        $this->assertMatchesRegularExpression("/N13 -> N17/", $dot);
-        $this->assertMatchesRegularExpression("/N39.*label.*Outcome=blue.*style=rounded/", $dot);
+        $this->assertEquals(strlen($dot), 3425);
+        $this->assertMatchesRegularExpression("/  N13 -> N17/", $dot);
+        $this->assertMatchesRegularExpression("/  N39.*label.*Outcome=blue.*style=.rounded/", $dot);
     }
 
     /**

--- a/tests/Classifiers/ClassificationTreeTest.php
+++ b/tests/Classifiers/ClassificationTreeTest.php
@@ -195,6 +195,11 @@ class ClassificationTreeTest extends TestCase
         $score = $this->metric->score($predictions, $testing->labels());
 
         $this->assertGreaterThanOrEqual(self::MIN_SCORE, $score);
+
+        $dot = $this->estimator->rules();
+        $this->assertEquals(strlen($dot), 2599);
+        $this->assertMatchesRegularExpression("/N13 -> N17/", $dot);
+        $this->assertMatchesRegularExpression("/N39.*label.*Outcome=blue.*style=rounded/", $dot);
     }
 
     /**

--- a/tests/Classifiers/ClassificationTreeTest.php
+++ b/tests/Classifiers/ClassificationTreeTest.php
@@ -196,10 +196,10 @@ class ClassificationTreeTest extends TestCase
 
         $this->assertGreaterThanOrEqual(self::MIN_SCORE, $score);
 
-        $dot = $this->estimator->rules();
+        $dot = $this->estimator->exportGraphviz();
         $this->assertEquals(strlen($dot), 3425);
-        $this->assertMatchesRegularExpression("/  N13 -> N17/", $dot);
-        $this->assertMatchesRegularExpression("/  N39.*label.*Outcome=blue.*style=.rounded/", $dot);
+        $this->assertMatchesRegularExpression('/  N13 -> N17/', $dot);
+        $this->assertMatchesRegularExpression('/  N39.*label.*Outcome=blue.*style=.rounded/', $dot);
     }
 
     /**


### PR DESCRIPTION
Following the discussion on #136, this change builds on the rules() method from a51d3f197602d624ffdcbc227c2569a0cd1d64f5 to produce a tree description for the graphviz package.

The string generated can be send through the dot command to produce an image.

A test case for is added to ClassificationTreeTest.php

Running this on the dataset from divorce produces an output like
```dot
digraph Tree {
node [shape=box, fontname=helvetica];
edge [fontname=helvetica];
N0 [label="Column_20 < 1"];
N1 [label="Column_52 < 0"];
N2 [label="Column_7 < 0"];
N3 [label="Outcome=divorced",style="rounded,filled",fillcolor=gray];
N2 -> N3;
N4 [label="Outcome=divorced",style="rounded,filled",fillcolor=gray];
N2 -> N4;
N1 -> N2;
...
```
That after running it through `dot -Tpng divorce.dot > divorce.png` renders as:

![divorce](https://user-images.githubusercontent.com/315403/153558778-3724fcc0-710d-4810-a6d2-7dfe0649fe5f.png)

Next steps: have a rulesGraphical that produces the image using an extra dependency. (This might be overkill to add a dependency on graphviz for every deployment of RubixML.)

