### PR TITLE
Updated import path for SVR example

### DIFF
--- a/docs/regressors/svr.md
+++ b/docs/regressors/svr.md
@@ -33,7 +33,7 @@ public load(string $path) : void
 
 ## Example
 ```php
-use Rubix\ML\Classifiers\SVR;
+use Rubix\ML\Regressors\SVR;
 use Rubix\ML\Kernels\SVM\RBF;
 
 $estimator = new SVR(1.0, 0.03, new RBF(), true, 1e-3, 256.0);


### PR DESCRIPTION
There is no `Rubix\ML\Classifiers\SVR`