### PR TITLE
Gower distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 - 2.2.0
     - Added Randomized Image Rotator transformer
+    - Added Gower distance kernel
 
 - 2.1.1
     - Do not consider unset properties when determining revision

--- a/benchmarks/Kernels/Distance/GowerBench.php
+++ b/benchmarks/Kernels/Distance/GowerBench.php
@@ -3,14 +3,14 @@
 namespace Rubix\ML\Benchmarks\Kernels\Distance;
 
 use Rubix\ML\Datasets\Generators\Blob;
-use Rubix\ML\Kernels\Distance\SafeEuclidean;
+use Rubix\ML\Kernels\Distance\Gower;
 use Rubix\ML\Transformers\LambdaFunction;
 
 /**
  * @Groups({"DistanceKernels"})
  * @BeforeMethods({"setUp"})
  */
-class SafeEuclideanBench
+class GowerBench
 {
     protected const NUM_SAMPLES = 10000;
 
@@ -25,7 +25,7 @@ class SafeEuclideanBench
     protected $bSamples;
 
     /**
-     * @var \Rubix\ML\Kernels\Distance\SafeEuclidean
+     * @var \Rubix\ML\Kernels\Distance\Gower
      */
     protected $kernel;
 
@@ -38,15 +38,22 @@ class SafeEuclideanBench
             $sample[5] = rand(0, 10) === 0 ? NAN : $sample[5];
         }));
 
+        $discretize = new LambdaFunction(function ($sample) {
+            $sample[6] = $sample[6] > 0.0 ? 'over' : 'under';
+            $sample[7] = abs($sample[7]) > 0.5 ? 'big' : 'small';
+        });
+
         $this->aSamples = $generator->generate(self::NUM_SAMPLES)
             ->apply($dropValues)
+            ->apply($discretize)
             ->samples();
 
         $this->bSamples = $generator->generate(self::NUM_SAMPLES)
             ->apply($dropValues)
+            ->apply($discretize)
             ->samples();
 
-        $this->kernel = new SafeEuclidean();
+        $this->kernel = new Gower(5.0);
     }
 
     /**

--- a/benchmarks/Kernels/Distance/SparseCosineBench.php
+++ b/benchmarks/Kernels/Distance/SparseCosineBench.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Rubix\ML\Benchmarks\Kernels\Distance;
+
+use Tensor\Matrix;
+use Rubix\ML\Kernels\Distance\SparseCosine;
+
+/**
+ * @Groups({"DistanceKernels"})
+ */
+class SparseCosineBench
+{
+    protected const NUM_SAMPLES = 10000;
+
+    /**
+     * @var list<list<float>>
+     */
+    protected $aSamples;
+
+    /**
+     * @var list<list<float>>
+     */
+    protected $bSamples;
+
+    /**
+     * @var \Rubix\ML\Kernels\Distance\SparseCosine
+     */
+    protected $kernel;
+
+    public function setUp() : void
+    {
+        $this->kernel = new SparseCosine();
+    }
+
+    public function setUpDense() : void
+    {
+        $this->aSamples = Matrix::gaussian(self::NUM_SAMPLES, 8)->asArray();
+        $this->bSamples = Matrix::gaussian(self::NUM_SAMPLES, 8)->asArray();
+    }
+
+    /**
+     * @Subject
+     * @Iterations(5)
+     * @BeforeMethods({"setUp", "setUpDense"})
+     * @OutputTimeUnit("milliseconds", precision=3)
+     */
+    public function computeDense() : void
+    {
+        array_map([$this->kernel, 'compute'], $this->aSamples, $this->bSamples);
+    }
+
+    public function setUpSparse() : void
+    {
+        $mask = Matrix::rand(self::NUM_SAMPLES, 8)
+            ->greater(0.5);
+
+        $this->aSamples = Matrix::gaussian(self::NUM_SAMPLES, 8)
+            ->multiply($mask)
+            ->asArray();
+
+        $mask = Matrix::rand(self::NUM_SAMPLES, 8)
+            ->greater(0.5);
+
+        $this->bSamples = Matrix::gaussian(self::NUM_SAMPLES, 8)
+            ->multiply($mask)
+            ->asArray();
+    }
+
+    /**
+     * @Subject
+     * @Iterations(5)
+     * @BeforeMethods({"setUp", "setUpSparse"})
+     * @OutputTimeUnit("milliseconds", precision=3)
+     */
+    public function computeSparse() : void
+    {
+        array_map([$this->kernel, 'compute'], $this->aSamples, $this->bSamples);
+    }
+
+    public function setUpVerySparse() : void
+    {
+        $mask = Matrix::rand(self::NUM_SAMPLES, 8)
+            ->greater(0.9);
+
+        $this->aSamples = Matrix::gaussian(self::NUM_SAMPLES, 8)
+            ->multiply($mask)
+            ->asArray();
+
+        $mask = Matrix::rand(self::NUM_SAMPLES, 8)
+            ->greater(0.9);
+
+        $this->bSamples = Matrix::gaussian(self::NUM_SAMPLES, 8)
+            ->multiply($mask)
+            ->asArray();
+    }
+
+    /**
+     * @Subject
+     * @Iterations(5)
+     * @BeforeMethods({"setUp", "setUpVerySparse"})
+     * @OutputTimeUnit("milliseconds", precision=3)
+     */
+    public function computeVerySparse() : void
+    {
+        array_map([$this->kernel, 'compute'], $this->aSamples, $this->bSamples);
+    }
+}

--- a/docs/kernels/distance/gower.md
+++ b/docs/kernels/distance/gower.md
@@ -10,7 +10,7 @@ A robust distance kernel that measures a mix of categorical and continuous data 
 ## Parameters
 | # | Param | Default | Type | Description |
 |---|---|---|---|---|
-| 1 | range | 1.0 | float | The range of the continuous feature columns. |
+| 1 | range | 1.0 | float | The standardized range of the continuous feature columns. |
 
 ## Example
 ```php

--- a/docs/kernels/distance/gower.md
+++ b/docs/kernels/distance/gower.md
@@ -1,0 +1,23 @@
+<span style="float:right;"><a href="https://github.com/RubixML/Extras/blob/master/src/Kernels/Distance/Gower.php">[source]</a></span>
+
+# Gower
+A robust distance kernel that measures a mix of categorical and continuous data types while handling NaN values. When comparing continuous data, the Gower metric is equivalent to the normalized [Manhattan](manhattan.md) distance and when comparing categorical data it is equivalent to the [Hamming](hamming.md) distance.
+
+> **Note:** The Gower metric expects all continuous variables to be on the same scale. By default, the range is between 0 and 1.
+
+**Data Type Compatibility:** Continuous, Categorical
+
+## Parameters
+| # | Param | Default | Type | Description |
+|---|---|---|---|---|
+| 1 | range | 1.0 | float | The range of the continuous feature columns. |
+
+## Example
+```php
+use Rubix\ML\Kernels\Distance\Gower;
+
+$kernel = new Gower(2.0);
+```
+
+### References
+>- J. C. Gower. (1971). A General Coefficient of Similarity and Some of Its Properties.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -203,6 +203,7 @@ nav:
         - Cosine: kernels/distance/cosine.md
         - Diagonal: kernels/distance/diagonal.md
         - Euclidean: kernels/distance/euclidean.md
+        - Gower: kernels/distance/gower.md
         - Hamming: kernels/distance/hamming.md
         - Jaccard: kernels/distance/jaccard.md
         - Manhattan: kernels/distance/manhattan.md

--- a/src/Kernels/Distance/Gower.php
+++ b/src/Kernels/Distance/Gower.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Rubix\ML\Kernels\Distance;
+
+use Rubix\ML\DataType;
+use Rubix\ML\Exceptions\InvalidArgumentException;
+
+use function count;
+
+/**
+ * Gower
+ *
+ * A generalized robust distance kernel that measures a mix of categorical and
+ * continuous data types while handling NaN values. When comparing continuous
+ * data, the Gower metric is equivalent to the normalized Manhattan distance
+ * and when comparing categorical data it is equivalent to the Hamming distance.
+ *
+ * > **Note:** The Gower metric expects that all continuous variables are on
+ * the same scale. By default, the range is between 0 and 1.
+ *
+ * References:
+ * [1] J. C. Gower. (1971). A General Coefficient of Similarity and Some of Its
+ * Properties.
+ *
+ * @category    Machine Learning
+ * @package     Rubix/ML
+ * @author      Andrew DalPino
+ */
+class Gower implements Distance, NaNSafe
+{
+    /**
+     * The range of the continuous feature columns.
+     *
+     * @var float
+     */
+    protected $range;
+
+    /**
+     * @param float $range
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
+     */
+    public function __construct(float $range = 1.0)
+    {
+        if ($range <= 0.0) {
+            throw new InvalidArgumentException('Range must be'
+                . " greater than 0, $range given.");
+        }
+
+        $this->range = $range;
+    }
+
+    /**
+     * Return the data types that this kernel is compatible with.
+     *
+     * @return \Rubix\ML\DataType[]
+     */
+    public function compatibility() : array
+    {
+        return [
+            DataType::categorical(),
+            DataType::continuous(),
+        ];
+    }
+
+    /**
+     * Compute the distance between two vectors.
+     *
+     * @param list<string|int|float> $a
+     * @param list<string|int|float> $b
+     * @return float
+     */
+    public function compute(array $a, array $b) : float
+    {
+        $distance = 0.0;
+        $nn = 0;
+
+        foreach ($a as $i => $valueA) {
+            $valueB = $b[$i];
+
+            switch (true) {
+                case is_float($valueA) and is_nan($valueA):
+                    ++$nn;
+
+                    break;
+
+                case is_float($valueB) and is_nan($valueB):
+                    ++$nn;
+
+                    break;
+
+                case !is_string($valueA) and !is_string($valueB):
+                    $distance += abs($valueA - $valueB)
+                        / $this->range;
+
+                    break;
+
+                default:
+                    if ($valueA !== $valueB) {
+                        $distance += 1.0;
+                    }
+            }
+        }
+
+        $n = count($a);
+
+        if ($nn === $n) {
+            return NAN;
+        }
+
+        return $distance / ($n - $nn);
+    }
+
+    /**
+     * Return the string representation of the object.
+     *
+     * @return string
+     */
+    public function __toString() : string
+    {
+        return "Gower (range: {$this->range})";
+    }
+}

--- a/tests/Kernels/Distance/GowerTest.php
+++ b/tests/Kernels/Distance/GowerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Rubix\ML\Tests\Kernels\Distance;
+
+use Rubix\ML\Kernels\Distance\Gower;
+use Rubix\ML\Kernels\Distance\NaNSafe;
+use Rubix\ML\Kernels\Distance\Distance;
+use PHPUnit\Framework\TestCase;
+use Generator;
+
+/**
+ * @group Distances
+ * @covers \Rubix\ML\Kernels\Distance\Gower
+ */
+class GowerTest extends TestCase
+{
+    /**
+     * @var \Rubix\ML\Kernels\Distance\Gower
+     */
+    protected $kernel;
+
+    /**
+     * @before
+     */
+    protected function setUp() : void
+    {
+        $this->kernel = new Gower(1.0);
+    }
+
+    /**
+     * @test
+     */
+    public function build() : void
+    {
+        $this->assertInstanceOf(Gower::class, $this->kernel);
+        $this->assertInstanceOf(NaNSafe::class, $this->kernel);
+        $this->assertInstanceOf(Distance::class, $this->kernel);
+    }
+
+    /**
+     * @test
+     * @dataProvider computeProvider
+     *
+     * @param list<string|int|float> $a
+     * @param list<string|int|float> $b
+     * @param float $expected
+     */
+    public function compute(array $a, array $b, $expected) : void
+    {
+        $distance = $this->kernel->compute($a, $b);
+
+        $this->assertGreaterThanOrEqual(0.0, $distance);
+        $this->assertEquals($expected, $distance);
+    }
+
+    /**
+     * @return \Generator<array<mixed>>
+     */
+    public function computeProvider() : Generator
+    {
+        yield [['toast', 1.0, 0.5, NAN], ['pretzels', 1.0, 0.2, 0.1], 0.43333333333333335];
+
+        yield [[0.0, 1.0, 0.5, 'ham'], [0.1, 0.9, 0.4, 'ham'], 0.07499999999999998];
+
+        yield [[1, NAN, 1], [1, NAN, 1], 0.0];
+    }
+}


### PR DESCRIPTION
This is the Gower distance kernel - a dual type, NaN-safe distance kernel that is pretty slow relative to other distance kernels but makes up for it by accepting pretty much any type of input including samples with missing values.