### PR TITLE
Column Filter Extractor

### DIFF
--- a/docs/extractors/column-filter.md
+++ b/docs/extractors/column-filter.md
@@ -1,0 +1,24 @@
+<span style="float:right;"><a href="https://github.com/RubixML/ML/blob/master/src/Extractors/ColumnFilter.php">[source]</a></span>
+
+# Column Filter
+
+**Interfaces:** [Extractor](api.md)
+
+## Parameters
+| # | Name | Default | Type | Description |
+|---|---|---|---|---|
+| 1 | iterator | | Traversable | The base iterator. |
+| 2 | keys | | array | The string and/or integer keys of the columns to filter from the table |
+
+## Example
+```php
+use Rubix\ML\Extractors\ColumnFilter;
+use Rubix\ML\Extractors\CSV;
+
+$extractor = new ColumnFilter(new CSV('example.csv', true), [
+    'texture', 'class',
+]);
+```
+
+## Additional Methods
+This extractor does not have any additional methods.

--- a/docs/extractors/column-picker.md
+++ b/docs/extractors/column-picker.md
@@ -4,6 +4,7 @@
 An extractor that wraps another iterator and selects and reorders the columns of the data table according to the keys specified by the user. The key of a column may either be a string or a column number (integer) depending on the way the columns are indexed in the base iterator.
 
 **Interfaces:** [Extractor](api.md)
+
 ## Parameters
 | # | Name | Default | Type | Description |
 |---|---|---|---|---|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
       - Verbose: verbose.md
     - Extractors:
       - API Reference: extractors/api.md
+      - Column Filter: extractors/column-filter.md
       - Column Picker: extractors/column-picker.md
       - Concatenator: extractors/concatenator.md
       - CSV: extractors/csv.md

--- a/src/Extractors/ColumnFilter.php
+++ b/src/Extractors/ColumnFilter.php
@@ -2,7 +2,6 @@
 
 namespace Rubix\ML\Extractors;
 
-use Rubix\ML\Exceptions\RuntimeException;
 use Traversable;
 
 /**

--- a/src/Extractors/ColumnFilter.php
+++ b/src/Extractors/ColumnFilter.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Rubix\ML\Extractors;
+
+use Rubix\ML\Exceptions\RuntimeException;
+use Traversable;
+
+/**
+ * Column Filter
+ *
+ * @category    Machine Learning
+ * @package     Rubix/ML
+ * @author      Andrew DalPino
+ */
+class ColumnFilter implements Extractor
+{
+    /**
+     * The base iterator.
+     *
+     * @var iterable<mixed[]>
+     */
+    protected iterable $iterator;
+
+    /**
+     * The string and/or integer keys of the columns to filter from the table.
+     *
+     * @var list<string|int>
+     */
+    protected array $columns;
+
+    /**
+     * @param iterable<mixed[]> $iterator
+     * @param (string|int)[] $columns
+     */
+    public function __construct(iterable $iterator, array $columns)
+    {
+        $this->iterator = $iterator;
+        $this->columns = array_values($columns);
+    }
+
+    /**
+     * Return an iterator for the records in the data table.
+     *
+     * @return \Generator<mixed[]>
+     */
+    public function getIterator() : Traversable
+    {
+        foreach ($this->iterator as $record) {
+            foreach ($this->columns as $column) {
+                if (isset($record[$column])) {
+                    unset($record[$column]);
+                }
+            }
+
+            yield $record;
+        }
+    }
+}

--- a/tests/Extractors/ColumnFilterTest.php
+++ b/tests/Extractors/ColumnFilterTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Rubix\ML\Tests\Extractors;
+
+use Rubix\ML\Extractors\CSV;
+use Rubix\ML\Extractors\Extractor;
+use Rubix\ML\Extractors\ColumnFilter;
+use PHPUnit\Framework\TestCase;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * @group Extractors
+ * @covers \Rubix\ML\Extractors\ColumnFilter
+ */
+class ColumnFilterTest extends TestCase
+{
+    /**
+     * @var \Rubix\ML\Extractors\ColumnFilter;
+     */
+    protected $extractor;
+
+    /**
+     * @before
+     */
+    protected function setUp() : void
+    {
+        $this->extractor = new ColumnFilter(new CSV('tests/test.csv', true), [
+            'texture',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function build() : void
+    {
+        $this->assertInstanceOf(ColumnFilter::class, $this->extractor);
+        $this->assertInstanceOf(Extractor::class, $this->extractor);
+        $this->assertInstanceOf(IteratorAggregate::class, $this->extractor);
+        $this->assertInstanceOf(Traversable::class, $this->extractor);
+    }
+
+    /**
+     * @test
+     */
+    public function extract() : void
+    {
+        $expected = [
+            ['attitude' => 'nice', 'class' => 'not monster', 'rating' => '4', 'sociability' => 'friendly'],
+            ['attitude' => 'mean', 'class' => 'monster', 'rating' => '-1.5', 'sociability' => 'loner'],
+            ['attitude' => 'nice', 'class' => 'not monster', 'rating' => '2.6', 'sociability' => 'friendly'],
+            ['attitude' => 'mean', 'class' => 'monster', 'rating' => '-1', 'sociability' => 'friendly'],
+            ['attitude' => 'nice', 'class' => 'not monster', 'rating' => '2.9', 'sociability' => 'friendly'],
+            ['attitude' => 'nice', 'class' => 'not monster', 'rating' => '-5', 'sociability' => 'loner'],
+        ];
+
+        $records = iterator_to_array($this->extractor, false);
+
+        $this->assertEquals($expected, $records);
+    }
+}


### PR DESCRIPTION
Similarly to Column Pick (https://docs.rubixml.com/2.0/extractors/column-picker.html) this Extractor iterates over a subset of the base iterator. However, unlike Column Picker, which selects the specified columns, this one filters them and selects the rest of the columns.

I found this to be useful when filtering columns like `ID` and `created_at` fields.