### PR TITLE
Bump flysystem to v2.1.1 or later

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/polyfill-php73": "^1.20",
         "symfony/polyfill-php80": "^1.17",
-        "league/flysystem": "~2.0.2"
+        "league/flysystem": "^2.1.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.18.*",


### PR DESCRIPTION
This patch allows updating flysystem to newer versions for projects that are still on 0.x.