### PR TITLE
Allow the phpstan composer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,10 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,
-        "process-timeout": 3000
+        "process-timeout": 3000,
+        "allow-plugins": {
+            "phpstan/extension-installer": false
+        }
     },
     "funding": [
         {


### PR DESCRIPTION
As seen in https://github.com/RubixML/ML/pull/261 CI fails for PRs against `0.0` due to the composer plugin not being allowed.