### PR TITLE
Drop Feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- 2.3.0
+    - Add `dropFeature()` method to the dataset object API
+
 - 2.2.0
     - Added Image Rotator transformer
     - Added One Vs Rest ensemble classifier

--- a/docs/datasets/api.md
+++ b/docs/datasets/api.md
@@ -101,6 +101,12 @@ Select the values of a feature column at a given offset :
 public feature(int $offset) : mixed[]
 ```
 
+## Dropping
+Drop a feature at a given column offset from the dataset:
+```php
+public dropFeature(int $offset) : self
+```
+
 ## Head and Tail
 Return the first *n* rows of data in a new dataset object:
 ```php

--- a/src/Datasets/Dataset.php
+++ b/src/Datasets/Dataset.php
@@ -197,6 +197,21 @@ abstract class Dataset implements ArrayAccess, IteratorAggregate, Countable
     }
 
     /**
+     * Drop a feature column at a given offset from the dataset.
+     *
+     * @param int $offset
+     * @return self
+     */
+    public function dropFeature(int $offset) : self
+    {
+        foreach ($this->samples as &$sample) {
+            array_splice($sample, $offset, 1);
+        }
+
+        return $this;
+    }
+
+    /**
      * Rotate the sample matrix so that the values of each feature become rows.
      *
      * @return mixed[]

--- a/src/Transformers/OneHotEncoder.php
+++ b/src/Transformers/OneHotEncoder.php
@@ -116,13 +116,13 @@ class OneHotEncoder implements Transformer, Stateful, Persistable
             foreach ($this->categories as $column => $categories) {
                 $category = $sample[$column];
 
-                $template = array_fill(0, count($categories), 0);
+                $vector = array_fill(0, count($categories), 0);
 
                 if (isset($categories[$category])) {
-                    $template[$categories[$category]] = 1;
+                    $vector[$categories[$category]] = 1;
                 }
 
-                $vectors[] = $template;
+                $vectors[] = $vector;
 
                 unset($sample[$column]);
             }

--- a/src/constants.php
+++ b/src/constants.php
@@ -9,7 +9,7 @@ namespace Rubix\ML
      *
      * @var string
      */
-    const VERSION = '2.2';
+    const VERSION = '2.3';
 
     /**
      * A small number used in substitution of 0.

--- a/tests/Datasets/LabeledTest.php
+++ b/tests/Datasets/LabeledTest.php
@@ -144,6 +144,25 @@ class LabeledTest extends TestCase
     /**
      * @test
      */
+    public function dropFeature() : void
+    {
+        $expected = [
+            ['nice', 'friendly', 4.0],
+            ['mean', 'loner', -1.5],
+            ['nice', 'friendly', 2.6],
+            ['mean', 'friendly', -1.0],
+            ['nice', 'friendly', 2.9],
+            ['nice', 'loner', -5.0],
+        ];
+
+        $this->dataset->dropFeature(1);
+
+        $this->assertEquals($expected, $this->dataset->samples());
+    }
+
+    /**
+     * @test
+     */
     public function numFeatures() : void
     {
         $this->assertEquals(4, $this->dataset->numFeatures());

--- a/tests/Datasets/UnlabeledTest.php
+++ b/tests/Datasets/UnlabeledTest.php
@@ -134,6 +134,25 @@ class UnlabeledTest extends TestCase
     /**
      * @test
      */
+    public function dropFeature() : void
+    {
+        $expected = [
+            ['nice', 'friendly', 4.0],
+            ['mean', 'loner', -1.5],
+            ['nice', 'friendly', 2.6],
+            ['mean', 'friendly', -1.0],
+            ['nice', 'friendly', 2.9],
+            ['nice', 'loner', -5.0],
+        ];
+
+        $this->dataset->dropFeature(1);
+
+        $this->assertEquals($expected, $this->dataset->samples());
+    }
+
+    /**
+     * @test
+     */
     public function numFeatures() : void
     {
         $this->assertEquals(4, $this->dataset->numFeatures());


### PR DESCRIPTION
This feature adds a method to the Dataset object API for dropping a single feature column from the dataset. I came into a need for this when writing the Churn tutorial. Specifically, we wanted to extract the customer ID from the database for use later but we don't need the ID for training or inference. 