### PR TITLE
GridSearch score sorting

### DIFF
--- a/src/GridSearch.php
+++ b/src/GridSearch.php
@@ -285,7 +285,7 @@ class GridSearch implements Estimator, Learner, Parallel, Verbose, Persistable
 
         $scores = $this->backend->process();
 
-        array_multisort($scores, $combinations, SORT_DESC);
+        array_multisort($scores, SORT_DESC, $combinations);
 
         $best = reset($combinations) ?: [];
 

--- a/tests/GridSearchTest.php
+++ b/tests/GridSearchTest.php
@@ -140,5 +140,13 @@ class GridSearchTest extends TestCase
         $score = $this->metric->score($predictions, $testing->labels());
 
         $this->assertGreaterThanOrEqual(self::MIN_SCORE, $score);
+
+        $expectedBest = [
+            'k' => 10,
+            'weighted' => true,
+            'kernel' => new Manhattan(),
+        ];
+
+        $this->assertEquals($expectedBest, $this->estimator->base()->params());
     }
 }


### PR DESCRIPTION
Current usage of array_multisort() doesn't seem to align with the intent of picking best score. 
``` 
$scores = $this->backend->process();
array_multisort($scores, $combinations, SORT_DESC);
$best = reset($combinations) ?: [];
````

SORT_DESC parameter is misplaced. Sorting function assumes SORT_ASC by default on $scores array thus the current implementation picks the lowest score.
```
$arr1 = [2, 3, 1];
$arr2 = ['two', 'three', 'one'];
array_multisort($arr1, $arr2, SORT_DESC);
echo reset($arr1); //outputs 1
```

Moving the parameter next to the array containing scores allows for proper sorting and resolves the issue.
````
array_multisort($arr1, SORT_DESC, $arr2);
echo reset($arr1); //outputs 3
````

Additional assertion has been added to GridSearchTest to validate best parameter selection.
(assuming deterministic nature of learner tests I'd hope that this implementation will suffice)