### PR TITLE
Improved psr/log dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "ext-json": "*",
         "amphp/parallel": "^1.3",
         "andrewdalpino/okbloomer": "^1.0",
-        "psr/log": "^1.1",
+        "psr/log": "^1.1|^2.0|^3.0",
         "rubix/tensor": "^3.0",
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/polyfill-php80": "^1.17",


### PR DESCRIPTION
As mentioned in #278, using psr/log ^1.x.x is blocking this project to be used on modern Frameworks such Laravel.

I used pipes "|" to allow the project use the best version of psr/log possible as needed by user's the project and others packages.

I also instaled the depencencies and runned `composer test`. It passed without any errors.