### PR TITLE
Added ability to set the escape character in CSV extractor.

### DIFF
--- a/docs/extractors/csv.md
+++ b/docs/extractors/csv.md
@@ -9,18 +9,19 @@ A plain-text format that use newlines to delineate rows and a user-specified del
 **Interfaces:** [Extractor](api.md), [Writable](api.md)
 
 ## Parameters
-| # | Name | Default | Type | Description |
-|---|---|---|---|---|
-| 1 | path |  | string | The path to the CSV file. |
-| 2 | header | false | bool | Does the CSV document have a header as the first row? |
-| 3 | delimiter | ',' | string | The character that delineates the values of the columns of the data table. |
-| 4 | enclosure | '"' | string | The character used to enclose a cell that contains a delimiter in the body. |
+| # | Name      | Default | Type | Description |
+|---|-----------|---------|---|---|
+| 1 | path      |         | string | The path to the CSV file. |
+| 2 | header    | false   | bool | Does the CSV document have a header as the first row? |
+| 3 | delimiter | ','     | string | The character that delineates the values of the columns of the data table. |
+| 4 | enclosure | '"'     | string | The character used to enclose a cell that contains a delimiter in the body. |
+| 5 | escape    | '\\'    | string | The character used as an escape character (one character only). Defaults as a backslash. |
 
 ## Example
 ```php
 use Rubix\ML\Extractors\CSV;
 
-$extractor = new CSV('example.csv', true, ',', '"');
+$extractor = new CSV('example.csv', true, ',', '"','\\');
 ```
 
 ## Additional Methods

--- a/src/Extractors/CSV.php
+++ b/src/Extractors/CSV.php
@@ -92,6 +92,10 @@ class CSV implements Extractor, Exporter
             throw new InvalidArgumentException('Path cannot be empty.');
         }
 
+        if (empty($escape)) {
+            throw new InvalidArgumentException('Escape character cannot be empty.');
+        }
+
         if (is_dir($path)) {
             throw new InvalidArgumentException('Path must be to a file, folder given.');
         }

--- a/src/Extractors/CSV.php
+++ b/src/Extractors/CSV.php
@@ -67,17 +67,26 @@ class CSV implements Extractor, Exporter
     protected string $enclosure;
 
     /**
+     * The character used as an escape character (one character only). Defaults as a backslash.
+     *
+     * @var non-empty-string
+     */
+    protected string $escape;
+
+    /**
      * @param string $path
      * @param bool $header
      * @param string $delimiter
      * @param string $enclosure
+     * @param string $escape
      * @throws \Rubix\ML\Exceptions\InvalidArgumentException
      */
     public function __construct(
         string $path,
         bool $header = false,
         string $delimiter = ',',
-        string $enclosure = '"'
+        string $enclosure = '"',
+        string $escape = '\\'
     ) {
         if (empty($path)) {
             throw new InvalidArgumentException('Path cannot be empty.');
@@ -101,6 +110,7 @@ class CSV implements Extractor, Exporter
         $this->header = $header;
         $this->delimiter = $delimiter;
         $this->enclosure = $enclosure;
+        $this->escape = $escape;
     }
 
     /**
@@ -140,7 +150,7 @@ class CSV implements Extractor, Exporter
         if ($this->header) {
             $header = array_keys(iterator_first($iterator));
 
-            $length = fputcsv($handle, $header, $this->delimiter, $this->enclosure);
+            $length = fputcsv($handle, $header, $this->delimiter, $this->enclosure, $this->escape);
 
             if ($length === false) {
                 throw new RuntimeException("Could not write header on line $line.");
@@ -150,7 +160,7 @@ class CSV implements Extractor, Exporter
         }
 
         foreach ($iterator as $row) {
-            $length = fputcsv($handle, $row, $this->delimiter, $this->enclosure);
+            $length = fputcsv($handle, $row, $this->delimiter, $this->enclosure, $this->escape);
 
             if ($length === false) {
                 throw new RuntimeException("Could not write row on line $line.");
@@ -187,7 +197,7 @@ class CSV implements Extractor, Exporter
         $line = 1;
 
         if ($this->header) {
-            $header = fgetcsv($handle, 0, $this->delimiter, $this->enclosure);
+            $header = fgetcsv($handle, 0, $this->delimiter, $this->enclosure, $this->escape);
 
             if (!$header) {
                 throw new RuntimeException("Header not found on line $line.");
@@ -197,7 +207,7 @@ class CSV implements Extractor, Exporter
         }
 
         while (!feof($handle)) {
-            $record = fgetcsv($handle, 0, $this->delimiter, $this->enclosure);
+            $record = fgetcsv($handle, 0, $this->delimiter, $this->enclosure, $this->escape);
 
             if (empty($record)) {
                 continue;


### PR DESCRIPTION
Hello again,
A lot of programs use different separators for csv (I personally encountered after I tried to import a csv from tableplus) The default for php is a backslash but it would be nice to be able to set, it this pr solves that.