### PR TITLE
Blob Simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- 2.5.0
+    - Blob Generator can now `simulate()` a Dataset object
+
 - 2.4.1
     - Sentence Tokenizer fix Arabic and Farsi language support
 

--- a/docs/datasets/generators/blob.md
+++ b/docs/datasets/generators/blob.md
@@ -17,8 +17,16 @@ A normally distributed (Gaussian) n-dimensional blob of samples centered at a gi
 ```php
 use Rubix\ML\Datasets\Generators\Blob;
 
-$generator = new Blob([-1.2, -5., 2.6, 0.8, 10.], 0.25);
+$generator = new Blob([-1.2, -5.0, 2.6, 0.8, 10.0], 0.25);
 ```
 
 ## Additional Methods
-This generator does not have any additional methods.
+Fit a Blob generator to the samples in a dataset.
+```php
+public static simulate(Dataset $dataset) : self
+```
+
+Return the center coordinates of the Blob.
+```php
+public center() : array
+```

--- a/src/Datasets/Generators/Blob.php
+++ b/src/Datasets/Generators/Blob.php
@@ -4,10 +4,14 @@ namespace Rubix\ML\Datasets\Generators;
 
 use Tensor\Matrix;
 use Tensor\Vector;
+use Rubix\ML\DataType;
+use Rubix\ML\Helpers\Stats;
+use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Datasets\Unlabeled;
 use Rubix\ML\Exceptions\InvalidArgumentException;
 
 use function count;
+use function sqrt;
 
 /**
  * Blob
@@ -36,6 +40,34 @@ class Blob implements Generator
      * @var \Tensor\Vector|int|float
      */
     protected $stdDev;
+
+    /**
+     * Fit a Blob generator to the samples in a dataset.
+     *
+     * @param \Rubix\ML\Datasets\Dataset $dataset
+     * @throws \Rubix\ML\Exceptions\InvalidArgumentException
+     * @return self
+     */
+    public static function simulate(Dataset $dataset) : self
+    {
+        $features = $dataset->featuresByType(DataType::continuous());
+
+        if (count($features) !== $dataset->numFeatures()) {
+            throw new InvalidArgumentException('Dataset must only contain'
+                . ' continuous features.');
+        }
+
+        $means = $stdDevs = [];
+
+        foreach ($features as $values) {
+            [$mean, $variance] = Stats::meanVar($values);
+
+            $means[] = $mean;
+            $stdDevs[] = sqrt($variance);
+        }
+
+        return new self($means, $stdDevs);
+    }
 
     /**
      * @param (int|float)[] $center
@@ -72,6 +104,16 @@ class Blob implements Generator
 
         $this->center = Vector::quick($center);
         $this->stdDev = $stdDev;
+    }
+
+    /**
+     * Return the center coordinates of the Blob.
+     *
+     * @return list<int|float>
+     */
+    public function center() : array
+    {
+        return $this->center->asArray();
     }
 
     /**

--- a/tests/Datasets/Generators/BlobTest.php
+++ b/tests/Datasets/Generators/BlobTest.php
@@ -32,10 +32,31 @@ class BlobTest extends TestCase
     /**
      * @test
      */
+    public function simulate() : void
+    {
+        $dataset = $this->generator->generate(100);
+
+        $generator = Blob::simulate($dataset);
+
+        $this->assertInstanceOf(Blob::class, $generator);
+        $this->assertInstanceOf(Generator::class, $generator);
+    }
+
+    /**
+     * @test
+     */
     public function build() : void
     {
         $this->assertInstanceOf(Blob::class, $this->generator);
         $this->assertInstanceOf(Generator::class, $this->generator);
+    }
+
+    /**
+     * @test
+     */
+    public function center() : void
+    {
+        $this->assertEquals([0, 0, 0], $this->generator->center());
     }
 
     /**


### PR DESCRIPTION
This adds a methos `simulate()` to the Blob generator allowing you to pass in a Dataset object and it will build a Blob generator that generates samples from the same Gaussian distribution as the Dataset object.