### PR TITLE
Fix multi bytes characters in some regex of RegexFilter

### DIFF
--- a/src/Transformers/RegexFilter.php
+++ b/src/Transformers/RegexFilter.php
@@ -59,7 +59,7 @@ class RegexFilter implements Transformer
      *
      * @var literal-string
      */
-    public const EXTRA_CHARACTERS = '/([^\w\s])(?=[^\w\s]*\1)/';
+    public const EXTRA_CHARACTERS = '/([^\w\s])(?=[^\w\s]*\1)/u';
 
     /**
      * Matches consecutively repeated words.
@@ -73,7 +73,7 @@ class RegexFilter implements Transformer
      *
      * @var literal-string
      */
-    public const EXTRA_WHITESPACE = '/\s(?=\s+)/';
+    public const EXTRA_WHITESPACE = '/\s(?=\s+)/u';
 
     /**
      * A pattern to match unicode emojis.
@@ -87,14 +87,14 @@ class RegexFilter implements Transformer
      *
      * @var literal-string
      */
-    public const MENTION = '/(@\w+)/';
+    public const MENTION = '/(@\w+)/u';
 
     /**
      * A pattern to match Twitter-style hashtags (ex. #MachineLearning).
      *
      * @var literal-string
      */
-    public const HASHTAG = '/(#\w+)/';
+    public const HASHTAG = '/(#\w+)/u';
 
     /**
      * A list of regular expression patterns used to filter the text columns of the dataset.

--- a/tests/Transformers/RegexFilterTest.php
+++ b/tests/Transformers/RegexFilterTest.php
@@ -33,7 +33,7 @@ class RegexFilterTest extends TestCase
             ['Too weird to live, support@rubixml.com too rare to die https://rubixml.com'],
             ['A man who procrastinates in @his choosing will inevitably have his choice    made for him by #circumstance'],
             ['The quick quick brown fox jumped over the lazy man sitting at a bus stop drinking a can of Cola cola'],
-            ['Diese äpfel Äpfel schmecken sehr gut'],
+            ['Diese₂ äpfel Äpfel schmecken sehr gut'],
         ]);
 
         $this->transformer = new RegexFilter([
@@ -68,7 +68,7 @@ class RegexFilterTest extends TestCase
             ['Too weird to live, too rare to die '],
             ['A man who procrastinates in choosing will inevitably have his choice made for him by '],
             ['The quick brown fox jumped over the lazy man sitting at a bus stop drinking a can of cola'],
-            ['Diese Äpfel schmecken sehr gut'],
+            ['Diese₂ Äpfel schmecken sehr gut'],
         ];
 
         $this->assertEquals($expected, $this->dataset->samples());


### PR DESCRIPTION
Problem: the replacement of multi bytes characters, without an ascii match, leads to a NULL