### PR TITLE
Allow normalizers to skip NaN values

### DIFF
--- a/src/Transformers/MaxAbsoluteScaler.php
+++ b/src/Transformers/MaxAbsoluteScaler.php
@@ -100,7 +100,7 @@ class MaxAbsoluteScaler implements Transformer, Stateful, Elastic, Reversible, P
         foreach ($this->maxabs as $column => $oldMax) {
             $values = $dataset->feature($column);
 
-            $max = max(array_map('abs', $values));
+            $max = max(array_map('abs', array_filter($values, 'is_finite')));
 
             $max = max($oldMax, $max);
 

--- a/src/Transformers/MaxAbsoluteScaler.php
+++ b/src/Transformers/MaxAbsoluteScaler.php
@@ -100,7 +100,7 @@ class MaxAbsoluteScaler implements Transformer, Stateful, Elastic, Reversible, P
         foreach ($this->maxabs as $column => $oldMax) {
             $values = $dataset->feature($column);
 
-            $max = max(array_map('abs', array_filter($values, 'is_finite')));
+            $max = max(array_map('abs', array_filter($values, 'is_finite') ?: [0]));
 
             $max = max($oldMax, $max);
 

--- a/src/Transformers/MinMaxNormalizer.php
+++ b/src/Transformers/MinMaxNormalizer.php
@@ -138,10 +138,10 @@ class MinMaxNormalizer implements Transformer, Stateful, Elastic, Reversible, Pe
                 $values = $dataset->feature($column);
 
                 /** @var int|float $min */
-                $min = min($values);
+                $min = min(array_filter($values, 'is_finite'));
 
                 /** @var int|float $max */
-                $max = max($values);
+                $max = max(array_filter($values, 'is_finite'));
 
                 $scale = ($this->max - $this->min) / (($max - $min) ?: EPSILON);
 
@@ -199,6 +199,10 @@ class MinMaxNormalizer implements Transformer, Stateful, Elastic, Reversible, Pe
             foreach ($this->scales as $column => $scale) {
                 $value = &$sample[$column];
 
+                if (!is_finite($value)) {
+                    continue;
+                }
+
                 $min = $this->minimums[$column];
 
                 $value *= $scale;
@@ -223,6 +227,10 @@ class MinMaxNormalizer implements Transformer, Stateful, Elastic, Reversible, Pe
         foreach ($samples as &$sample) {
             foreach ($this->scales as $column => $scale) {
                 $value = &$sample[$column];
+
+                if (!is_finite($value)) {
+                    continue;
+                }
 
                 $min = $this->minimums[$column];
 

--- a/src/Transformers/MinMaxNormalizer.php
+++ b/src/Transformers/MinMaxNormalizer.php
@@ -138,10 +138,10 @@ class MinMaxNormalizer implements Transformer, Stateful, Elastic, Reversible, Pe
                 $values = $dataset->feature($column);
 
                 /** @var int|float $min */
-                $min = min(array_filter($values, 'is_finite'));
+                $min = min(array_filter($values, 'is_finite') ?: [0]);
 
                 /** @var int|float $max */
-                $max = max(array_filter($values, 'is_finite'));
+                $max = max(array_filter($values, 'is_finite') ?: [0]);
 
                 $scale = ($this->max - $this->min) / (($max - $min) ?: EPSILON);
 

--- a/tests/Transformers/MaxAbsoluteScalerTest.php
+++ b/tests/Transformers/MaxAbsoluteScalerTest.php
@@ -109,4 +109,15 @@ class MaxAbsoluteScalerTest extends TestCase
 
         $this->transformer->reverseTransform($samples);
     }
+
+    /**
+     * @test
+     */
+    public function skipsNonFinite(): void
+    {
+        $samples = Unlabeled::build([[0.0, 3000.0, NAN, -6.0], [1.0, 30.0, NAN, 0.001]]);
+        $this->transformer->fit($samples);
+        $this->assertNan($samples[0][2]);
+        $this->assertNan($samples[1][2]);
+    }
 }

--- a/tests/Transformers/MinMaxNormalizerTest.php
+++ b/tests/Transformers/MinMaxNormalizerTest.php
@@ -102,4 +102,15 @@ class MinMaxNormalizerTest extends TestCase
 
         $this->transformer->transform($samples);
     }
+
+    /**
+     * @test
+     */
+    public function skipsNonFinite(): void
+    {
+        $samples = Unlabeled::build([[0.0, 3000.0, NAN, -6.0], [1.0, 30.0, NAN, 0.001]]);
+        $this->transformer->fit($samples);
+        $this->assertNan($samples[0][2]);
+        $this->assertNan($samples[1][2]);
+    }
 }


### PR DESCRIPTION
Hi,

I have a dataset with a lot of missing data, and I wanted to use the `HotDeckImputer` with the `Gower` kernel to fill in the blanks. I had preprocessed my dataset so that `null`s were converted to `NAN` or `?` depending on the data type.

The problem was then that `Gower` expects continuous features to have been normalized. I then wanted to use the `MinMaxNormalizer` to do this on the continuous features in the dataset, but it doesn't handle `NAN` - essentially every value is normalized to zero.

I updated the `MinMaxNormalizer` and the `MaxAbsoluteScaler` to skip `NAN` values, and compute min/max or abs only the finite values and leave the `NAN` values where they were in the original dataset.

Being new to ML, I wasn't sure if this was a valid approach for using the normalizers together with the Gower imputer - feedback welcome!