### PR TITLE
Enable the OneHotEncoder to be able to drop categories

### DIFF
--- a/docs/transformers/one-hot-encoder.md
+++ b/docs/transformers/one-hot-encoder.md
@@ -8,7 +8,9 @@ The One Hot Encoder takes a categorical feature column and produces an n-dimensi
 **Data Type Compatibility:** Categorical
 
 ## Parameters
-This transformer does not have any parameters.
+| # | Name | Default | Type           | Description |
+|---|------|---------|----------------|-------------|
+| 1 | drop | []      | array\|string | The list of categories to drop (ignore) during categorization |
 
 ## Example
 ```php

--- a/src/Transformers/OneHotEncoder.php
+++ b/src/Transformers/OneHotEncoder.php
@@ -42,11 +42,25 @@ class OneHotEncoder implements Transformer, Stateful, Persistable
     protected ?array $categories = null;
 
     /**
+     * The categories that should be ignored
+     *
+     * @var array<string>
+     */
+    protected array $drop = [];
+
+    /**
+     * @param string|array $drop The categories to drop during encoding
+     */
+    public function __construct($drop = [])
+    {
+        $this->drop = is_array($drop) ? $drop : [$drop];
+    }
+
+    /**
      * Return the data types that this transformer is compatible with.
      *
-     * @internal
-     *
      * @return list<\Rubix\ML\DataType>
+     * @internal
      */
     public function compatibility() : array
     {
@@ -87,6 +101,8 @@ class OneHotEncoder implements Transformer, Stateful, Persistable
         foreach ($dataset->featureTypes() as $column => $type) {
             if ($type->isCategorical()) {
                 $values = $dataset->feature($column);
+
+                $values = array_diff($values, $this->drop);
 
                 $categories = array_values(array_unique($values));
 

--- a/tests/Transformers/OneHotEncoderTest.php
+++ b/tests/Transformers/OneHotEncoderTest.php
@@ -2,11 +2,11 @@
 
 namespace Rubix\ML\Tests\Transformers;
 
+use PHPUnit\Framework\TestCase;
 use Rubix\ML\Datasets\Unlabeled;
+use Rubix\ML\Transformers\OneHotEncoder;
 use Rubix\ML\Transformers\Stateful;
 use Rubix\ML\Transformers\Transformer;
-use Rubix\ML\Transformers\OneHotEncoder;
-use PHPUnit\Framework\TestCase;
 
 /**
  * @group Transformers
@@ -66,6 +66,42 @@ class OneHotEncoderTest extends TestCase
             [0, 1, 1, 0, 0, 1],
             [1, 0, 0, 1, 1, 0],
             [0, 1, 0, 1, 1, 0],
+        ];
+
+        $this->assertEquals($expected, $dataset->samples());
+    }
+
+    /**
+     * @test
+     */
+    public function fitTransformNone() : void
+    {
+        $dataset = new Unlabeled([
+            ['nice', 'furry', 'friendly'],
+            ['mean', 'furry', 'loner'],
+            ['nice', 'rough', 'friendly'],
+            ['mean', 'rough', 'friendly'],
+        ]);
+
+        $this->transformer = new OneHotEncoder('furry');
+
+        $this->transformer->fit($dataset);
+
+        $this->assertTrue($this->transformer->fitted());
+
+        $categories = $this->transformer->categories();
+
+        $this->assertIsArray($categories);
+        $this->assertCount(3, $categories);
+        $this->assertContainsOnly('array', $categories);
+
+        $dataset->apply($this->transformer);
+
+        $expected = [
+            [1, 0, 0, 1, 0],
+            [0, 1, 0, 0, 1],
+            [1, 0, 1, 1, 0],
+            [0, 1, 1, 1, 0],
         ];
 
         $this->assertEquals($expected, $dataset->samples());


### PR DESCRIPTION
Hi,

I've been working with a sparse dataset, in which my '?' category should really be represented as none of the generated features being hot when using the `OneHotEncoder`.

This contribution adds this as a backwards-compatible option to the encoder.