### PR TITLE
Correct the samples formatting to get a good SVR

### DIFF
--- a/src/Regressors/SVR.php
+++ b/src/Regressors/SVR.php
@@ -235,8 +235,12 @@ class SVR implements Estimator, Learner
         if (!$this->model) {
             throw new RuntimeException('Estimator has not been trained.');
         }
-
-        return $this->model->predict($sample);
+        //As SVM needs to have the same keys and order between training samples and those to predict we need to put an offset to the keys
+        $sampleWithOffset = [];
+        foreach($sample as $key=>$value){
+            $sampleWithOffset[$key+1] = $value;
+        }
+        return $this->model->predict($sampleWithOffset);
     }
 
     /**


### PR DESCRIPTION
**Just like the doc says :**

In a document classification problem, say a spam checker, each line would represent a document. There would be two classes, -1 for spam, 1 for ham. Each feature would represent some word, and the value would represent that importance of that word to the document (perhaps the frequency count, with the total scaled to unit length). Features that were 0 (e.g. the word did not appear in the document at all) would simply not be included.

In array mode, the data must be passed as an array of arrays. Each sub-array must have the class as the first element, then key => value sets for the feature values pairs.

This data is passed to the SVM class's train function, which will return an SVM model is successful.

Once a model has been generated, it can be used to make predictions about previously unseen data. This can be passed as an array to the model's predict function, in the same format as before, but without the label. The response will be the class.

Models can be saved and restored as required, using the save and load functions, which both take a file location.

Example #1 Train from array
<?php
$data = array(
    array(-1, 1 => 0.43, 3 => 0.12, 9284 => 0.2),
    array(1, 1 => 0.22, 5 => 0.01, 94 => 0.11),
);

$svm = new SVM();
$model = $svm->train($data);

$data = array(1 => 0.43, 3 => 0.12, 9284 => 0.2);
$result = $model->predict($data);
var_dump($result);
$model->save('model.svm');
?>
