### PR TITLE
Correct the samples formatting to get a good SVC

### DIFF
--- a/src/Classifiers/SVC.php
+++ b/src/Classifiers/SVC.php
@@ -236,7 +236,12 @@ class SVC implements Estimator, Learner
             throw new RuntimeException('Estimator has not been trained.');
         }
 
-        $index = $this->model->predict($sample);
+        $sampleWithOffset = [];
+        foreach($sample as $key=>$value){
+            $sampleWithOffset[$key+1] = $value;
+        }
+
+        $index = $this->model->predict($sampleWithOffset);
 
         return $this->classes[$index];
     }


### PR DESCRIPTION
Just like the doc says (https://www.php.net/manual/en/svm.examples.php)

In a document classification problem, say a spam checker, each line would represent a document. There would be two classes, -1 for spam, 1 for ham. Each feature would represent some word, and the value would represent that importance of that word to the document (perhaps the frequency count, with the total scaled to unit length). Features that were 0 (e.g. the word did not appear in the document at all) would simply not be included.

In array mode, the data must be passed as an array of arrays. Each sub-array must have the class as the first element, then key => value sets for the feature values pairs.

This data is passed to the SVM class's train function, which will return an SVM model is successful.

Once a model has been generated, it can be used to make predictions about previously unseen data. This can be passed as an array to the model's predict function, in the same format as before, but without the label. The response will be the class.

Models can be saved and restored as required, using the save and load functions, which both take a file location.