### PR TITLE
chore(deps): Update `php-stemmer` to version `^4.0` for PHP 8.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "symfony/polyfill-php80": "^1.17",
         "symfony/polyfill-php82": "^1.27",
         "symfony/polyfill-php83": "^1.27",
-        "wamania/php-stemmer": "^3.0"
+        "wamania/php-stemmer": "^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",


### PR DESCRIPTION
`php-stemmer` v3.0 used [`voku/portable-utf8`](https://github.com/voku/portable-utf8) which throws several deprecation warnings when using PHP 8.4 (see #359). As `portable-utf8` isn't that well maintained, the developer switched to [`joomla/string`](https://github.com/joomla-framework/string) instead.

This is a fully backward-compatible change inside `php-stemmer`. The API and behavior didn't change at all and the version bump is made just-in-case, which means that no additional code changes are necessary.

This fixes #359.